### PR TITLE
Add bootstrap-servers property that enables discovering of the kafka server

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
@@ -40,7 +40,7 @@ public class OrdersKafkaConsumer implements InitializingBean {
 
     private CHKafkaResilientConsumerGroup chKafkaConsumerGroupMain;
     private CHKafkaResilientConsumerGroup chKafkaConsumerGroupRetry;
-    @Value("${kafka.broker.addresses}")
+    @Value("${spring.kafka.consumer.bootstrap-servers}")
     private String brokerAddresses;
     private final SerializerFactory serializerFactory;
 
@@ -119,7 +119,7 @@ public class OrdersKafkaConsumer implements InitializingBean {
             config.setBrokerAddresses(brokerAddresses.split(","));
         } else {
             throw new ProducerConfigException("Broker addresses for kafka broker missing, check if environment variable KAFKA_BROKER_ADDR is configured. " +
-                    "[Hint: The property 'kafka.broker.addresses' uses the value of this environment variable in live environments " +
+                    "[Hint: The property 'spring.kafka.consumer.bootstrap-servers' uses the value of this environment variable in live environments " +
                     "and that of 'spring.embedded.kafka.brokers' property in test.]");
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ uk.gov.companieshouse.item-handler.health: /healthcheck
 uk.gov.companieshouse.item-handler.error-consumer: ${IS_ERROR_QUEUE_CONSUMER}
 
 kafka.broker.addresses: ${KAFKA_BROKER_ADDR}
+spring.kafka.consumer.bootstrap-servers: ${KAFKA_BROKER_ADDR}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,4 @@ server.servlet.context-path: /item-handler
 uk.gov.companieshouse.item-handler.health: /healthcheck
 uk.gov.companieshouse.item-handler.error-consumer: ${IS_ERROR_QUEUE_CONSUMER}
 
-kafka.broker.addresses: ${KAFKA_BROKER_ADDR}
 spring.kafka.consumer.bootstrap-servers: ${KAFKA_BROKER_ADDR}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationDefaultModeTest.java
@@ -44,7 +44,7 @@ public class OrdersKafkaConsumerIntegrationDefaultModeTest {
     private static final String ORDER_RECEIVED_TOPIC_ERROR = "order-received-error";
     private static final String GROUP_NAME = "order-received-consumers";
     private static final String ORDER_RECEIVED_URI = "/order/ORDER-12345";
-    @Value("${kafka.broker.addresses}")
+    @Value("${spring.kafka.consumer.bootstrap-servers}")
     private String brokerAddresses;
 
     private KafkaTemplate<String, String> template;

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationErrorModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationErrorModeTest.java
@@ -44,7 +44,7 @@ public class OrdersKafkaConsumerIntegrationErrorModeTest {
     private static final String ORDER_RECEIVED_TOPIC_ERROR = "order-received-error";
     private static final String CONSUMER_GROUP_MAIN_RETRY = "order-received-main-retry";
     private static final String ORDER_RECEIVED_URI = "/order/ORDER-12345";
-    @Value("${kafka.broker.addresses}")
+    @Value("${spring.kafka.consumer.bootstrap-servers}")
     private String brokerAddresses;
 
     private KafkaTemplate<String, String> template;

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerWrapper.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerWrapper.java
@@ -28,7 +28,7 @@ public class OrdersKafkaConsumerWrapper {
     private CountDownLatch latch = new CountDownLatch(1);
     private String orderUri;
     private CHConsumerType testType = CHConsumerType.MAIN_CONSUMER;
-    @Value("${kafka.broker.addresses}")
+    @Value("${spring.kafka.consumer.bootstrap-servers}")
     private String brokerAddresses;
     private KafkaTemplate<String, String> template;
     private static final String ORDER_RECEIVED_TOPIC = "order-received";

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,5 @@
 uk.gov.companieshouse.item-handler.health: /healthcheck
 
-kafka.broker.addresses: ${spring.embedded.kafka.brokers}
 spring.kafka.consumer.bootstrap-servers: ${spring.embedded.kafka.brokers}
 kafka.topic.receiver: order-received
 


### PR DESCRIPTION
This property addition enables `item-handler` to discover the kafka server that hosts the topic (`order-received`) that it needs to listen to.