### PR TITLE
Create demo for @Retryable implementation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/controller/HealthcheckController.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/controller/HealthcheckController.java
@@ -1,9 +1,20 @@
 package uk.gov.companieshouse.itemhandler.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.itemhandler.kafka.OrdersKafkaProducer;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.kafka.message.Message;
+import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+import uk.gov.companieshouse.orders.OrderReceived;
+
+import java.util.Date;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Returns HTTP OK response to indicate a healthy service is running
@@ -13,5 +24,32 @@ public class HealthcheckController {
     @GetMapping("${uk.gov.companieshouse.item-handler.health}")
     public ResponseEntity<Void> getHealthCheck (){
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @Autowired
+    private SerializerFactory serializerFactory;
+    @Autowired
+    private OrdersKafkaProducer producer;
+
+    @GetMapping("/test/{uri}")
+    public ResponseEntity<Void> testKafka(@PathVariable("uri") String uri)
+            throws SerializationException, ExecutionException, InterruptedException {
+        Message message = createRetryMessage("/orders/" + uri, "order-received");
+        producer.sendMessage(message);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    protected Message createRetryMessage(String orderUri, String topic) throws SerializationException {
+        final Message message = new Message();
+        AvroSerializer serializer = serializerFactory.getGenericRecordSerializer(OrderReceived.class);
+        OrderReceived orderReceived = new OrderReceived();
+        orderReceived.setOrderUri(orderUri.trim());
+
+        message.setKey("order-received");
+        message.setValue(serializer.toBinary(orderReceived));
+        message.setTopic(topic);
+        message.setTimestamp(new Date().getTime());
+
+        return message;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
@@ -12,6 +12,7 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemhandler.exception.RetryableErrorException;
+import uk.gov.companieshouse.itemhandler.service.EmailService;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
@@ -47,13 +48,16 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
     private final SerializerFactory serializerFactory;
     private final OrdersKafkaProducer kafkaProducer;
     private final KafkaListenerEndpointRegistry registry;
+    private final EmailService emailService;
 
     public OrdersKafkaConsumer(SerializerFactory serializerFactory,
                                OrdersKafkaProducer kafkaProducer,
-                               KafkaListenerEndpointRegistry registry) {
+                               KafkaListenerEndpointRegistry registry,
+                               EmailService emailer) {
         this.serializerFactory = serializerFactory;
         this.kafkaProducer = kafkaProducer;
         this.registry = registry;
+        this.emailService = emailer;
     }
 
     /**
@@ -134,6 +138,7 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
             logMessageReceived(message);
 
             // process message
+            emailService.processMessage(message);
 
             logMessageProcessed(message);
         } catch (RetryableErrorException ex){

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaRetryable.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaRetryable.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.itemhandler.kafka;
+
+import org.springframework.messaging.Message;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import uk.gov.companieshouse.itemhandler.exception.RetryableErrorException;
+import uk.gov.companieshouse.orders.OrderReceived;
+
+public interface OrdersKafkaRetryable {
+    /**
+     * A retryable method that runs itself `maxAttempts` times when its implementation throws a RetryableErrorException.
+     * By default `maxAttempts`, a `@Retryable` property, is set to 3.
+     * @param message message to be processed
+     * @throws Exception
+     */
+    @Retryable(value = RetryableErrorException.class, backoff = @Backoff(delay = 5000))
+    void processMessage(Message<OrderReceived> message) throws Exception;
+}

--- a/src/main/java/uk/gov/companieshouse/itemhandler/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/service/EmailService.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.itemhandler.service;
+
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.itemhandler.exception.RetryableErrorException;
+import uk.gov.companieshouse.itemhandler.kafka.OrdersKafkaRetryable;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.orders.OrderReceived;
+
+import static uk.gov.companieshouse.itemhandler.ItemHandlerApplication.APPLICATION_NAMESPACE;
+
+@Service
+public class EmailService implements OrdersKafkaRetryable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
+
+    @Override
+    public void processMessage(Message<OrderReceived> message) throws RetryableErrorException {
+        OrderReceived msg = message.getPayload();
+        String orderReceivedUri = msg.getOrderUri();
+        LOGGER.info(String.format("Message \"%1$s\" received for processing.", orderReceivedUri));
+        throw new RetryableErrorException("Mock exception");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerTest.java
@@ -14,6 +14,7 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.messaging.MessageHeaders;
 import uk.gov.companieshouse.itemhandler.exception.RetryableErrorException;
+import uk.gov.companieshouse.itemhandler.service.EmailService;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
@@ -55,7 +56,8 @@ public class OrdersKafkaConsumerTest {
     public void createRetryMessageBuildsMessageSuccessfully() throws SerializationException {
         // Given & When
         OrdersKafkaConsumer consumerUnderTest =
-                new OrdersKafkaConsumer(new SerializerFactory(), new OrdersKafkaProducer(), new KafkaListenerEndpointRegistry());
+                new OrdersKafkaConsumer(new SerializerFactory(), new OrdersKafkaProducer(),
+                        new KafkaListenerEndpointRegistry(), new EmailService());
         Message actualMessage = consumerUnderTest.createRetryMessage(ORDER_RECEIVED_URI, ORDER_RECEIVED_TOPIC);
         byte[] actualMessageRawValue    = actualMessage.getValue();
         byte[] expectedMessageRawValue  = EXPECTED_MESSAGE_VALUE.getBytes();

--- a/start.sh
+++ b/start.sh
@@ -27,5 +27,5 @@ else
     source "${APP_DIR}/app_env"
 fi
 
-exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/item-handler.jar"
-
+#exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/item-handler.jar"
+exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21092 -jar -Dserver.port="${PORT}" "${APP_DIR}/item-handler.jar"


### PR DESCRIPTION
This is a demo to showcase how `@Retryable` is to be used to retry recoverable errors in kafka message processing.

To use the demo simply build and run the application. When the application is ready
* make a GET request (in browser) to the test endpoint 
`http://chs-dev:10022/item-handler/test/{test-uri}` where `{test-uri}` is a random alphanumeric string
* as the request is processed, watch the console logs display the message being received by main consumer, processed three times (failing with a recoverable error, each time) and then published to `-retry` and `-error` topics.