### PR TITLE
Fix for extra retry and offset seek errors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
@@ -157,9 +157,9 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
             }
         }
         else {
+            retryCount.put(counterKey, retryCount.getOrDefault(counterKey, 1) + 1);
             // retry
             handleMessage(message);
-            retryCount.put(counterKey, retryCount.getOrDefault(counterKey, 1) + 1);
             logMessageProcessingFailureRecoverable(message, retryCount.get(counterKey), ex);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
@@ -150,16 +150,17 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
         String counterKey = receivedTopic + "-" + orderReceivedUri;
 
         if (receivedTopic.equals(ORDER_RECEIVED_TOPIC)
-                || retryCount.getOrDefault(counterKey, 0) >= MAX_RETRY_ATTEMPTS) {
+                || retryCount.getOrDefault(counterKey, 1) >= MAX_RETRY_ATTEMPTS) {
             republishMessageToTopic(orderReceivedUri, receivedTopic, nextTopic);
             if (!receivedTopic.equals(ORDER_RECEIVED_TOPIC)) {
                 resetRetryCount(counterKey);
             }
         }
         else {
-            retryCount.put(counterKey, retryCount.getOrDefault(counterKey, 0) + 1);
-            logMessageProcessingFailureRecoverable(message, retryCount.get(counterKey), ex);
             // retry
+            handleMessage(message);
+            retryCount.put(counterKey, retryCount.getOrDefault(counterKey, 1) + 1);
+            logMessageProcessingFailureRecoverable(message, retryCount.get(counterKey), ex);
         }
     }
 
@@ -276,7 +277,6 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
                         (topic, action) ->
                         {
                             updateErrorRecoveryOffset(topicPartitionsMap.get(topic) - 1);
-                            consumerSeekCallback.seek(topic.topic(), topic.partition(), errorRecoveryOffset);
                             LOGGER.info(String.format("Setting Error Consumer Recovery Offset to '%1$d'", errorRecoveryOffset));
                         }
                 );

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
@@ -158,9 +158,9 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
         }
         else {
             retryCount.put(counterKey, retryCount.getOrDefault(counterKey, 1) + 1);
+            logMessageProcessingFailureRecoverable(message, retryCount.get(counterKey), ex);
             // retry
             handleMessage(message);
-            logMessageProcessingFailureRecoverable(message, retryCount.get(counterKey), ex);
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerTest.java
@@ -110,7 +110,7 @@ public class OrdersKafkaConsumerTest {
     @Test
     public void republishMessageNotCalledForFirstRetryMessageOnRetryableErrorException() {
         // Given & When
-        doThrow(new RetryableErrorException(PROCESSING_ERROR_MESSAGE)).when(ordersKafkaConsumer).logMessageReceived(any());
+        doThrow(new RetryableErrorException(PROCESSING_ERROR_MESSAGE)).doNothing().when(ordersKafkaConsumer).logMessageReceived(any());
         ordersKafkaConsumer.handleMessage(createTestMessage(ORDER_RECEIVED_TOPIC_RETRY));
         // Then
         verify(ordersKafkaConsumer, times(0)).republishMessageToTopic(anyString(), anyString(), anyString());
@@ -119,7 +119,7 @@ public class OrdersKafkaConsumerTest {
     @Test
     public void republishMessageNotCalledForFirstErrorMessageOnRetryableErrorException() {
         // Given & When
-        doThrow(new RetryableErrorException(PROCESSING_ERROR_MESSAGE)).when(ordersKafkaConsumer).logMessageReceived(any());
+        doThrow(new RetryableErrorException(PROCESSING_ERROR_MESSAGE)).doNothing().when(ordersKafkaConsumer).logMessageReceived(any());
         ordersKafkaConsumer.handleMessage(createTestMessage(ORDER_RECEIVED_TOPIC_ERROR));
         // Then
         verify(ordersKafkaConsumer, times(0)).republishMessageToTopic(anyString(), anyString(), anyString());


### PR DESCRIPTION
This fixes issues with
* retry count so retries do not exceed `MAX_RETRY_ATTEPTS`
* adds a retry call to `handleMessage()`
* removes consumer offset seek call that moves offset position to last but one offset.