### PR TITLE
Set kafka consumer auto-offset-reset property and change test consumer advice to Around

### DIFF
--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationDefaultModeTest.java
@@ -38,7 +38,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 
 @SpringBootTest
-@DirtiesContext
 @EmbeddedKafka
 @TestPropertySource(properties={"uk.gov.companieshouse.item-handler.error-consumer=false",
                                 "certificate.order.confirmation.recipient = nobody@nowhere.com"})

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationDefaultModeTest.java
@@ -142,7 +142,7 @@ public class OrdersKafkaConsumerIntegrationDefaultModeTest {
 
     private void verifyProcessOrderReceivedInvoked(CHConsumerType type) throws InterruptedException {
         consumerWrapper.setTestType(type);
-        consumerWrapper.getLatch().await(30000, TimeUnit.MILLISECONDS);
+        consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         assertThat(consumerWrapper.getLatch().getCount(), is(equalTo(0L)));
         String processedOrderUri = consumerWrapper.getOrderUri();
         assertThat(processedOrderUri, is(equalTo(ORDER_RECEIVED_MESSAGE_JSON)));

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerWrapper.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerWrapper.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.itemhandler.kafka;
 
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,9 +77,9 @@ public class OrdersKafkaConsumerWrapper {
      * emulates receiving of message from kafka topics
      * @param message
      */
-    @After(value = "execution(* uk.gov.companieshouse.itemhandler.kafka.OrdersKafkaConsumer.*(..)) && args(message)")
-    public void afterOrderProcessed(final Message message){
-        LOGGER.info("OrdersKafkaConsumer.processOrderReceivedRetry() @After triggered");
+    @Around(value = "execution(* uk.gov.companieshouse.itemhandler.kafka.OrdersKafkaConsumer.*(..)) && args(message)")
+    public void aroundOrderProcessed(final Message message){
+        LOGGER.info("OrdersKafkaConsumer.processOrderReceivedRetry() @Around triggered");
         this.orderUri = "" + message.getPayload();
         latch.countDown();
     }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,7 @@
 uk.gov.companieshouse.item-handler.health = /healthcheck
 
 spring.kafka.consumer.bootstrap-servers = ${spring.embedded.kafka.brokers}
+spring.kafka.consumer.auto-offset-reset = earliest
 kafka.topic.receiver = order-received
 
 uk.gov.companieshouse.item-handler.error-consumer = false


### PR DESCRIPTION
This is another attempt to stabilise build and test run failures due to coundown latch based tests.