### PR TITLE
Upgrade maven plugin to overcome * exclusion build warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<spring-boot-dependencies.version>2.1.15.RELEASE</spring-boot-dependencies.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-		<spring-boot-maven-plugin.version>2.1.15.RELEASE</spring-boot-maven-plugin.version>
+		<spring-boot-maven-plugin.version>2.3.1.RELEASE</spring-boot-maven-plugin.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
This bumps up the Spring Boot maven plugin to the latest version to overcome '*' exclusion build warnings.  