### PR TITLE
Remove resetting of countdown latch

### DIFF
--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationDefaultModeTest.java
@@ -70,7 +70,6 @@ public class OrdersKafkaConsumerIntegrationDefaultModeTest {
 
     @AfterEach
     public void tearDown() {
-        consumerWrapper.reset();
         container.stop();
     }
 

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationErrorModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerIntegrationErrorModeTest.java
@@ -70,7 +70,6 @@ public class OrdersKafkaConsumerIntegrationErrorModeTest {
 
     @AfterEach
     public void tearDown() {
-        consumerWrapper.reset();
         container.stop();
     }
 

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerWrapper.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumerWrapper.java
@@ -87,8 +87,6 @@ public class OrdersKafkaConsumerWrapper {
     CountDownLatch getLatch() { return latch; }
     String getOrderUri() { return orderUri; }
     void setTestType(CHConsumerType type) { this.testType = type;}
-    CHConsumerType getTestType() { return this.testType; }
-    void reset() { this.latch = new CountDownLatch(1); }
 
     private void setUpTestKafkaOrdersProducerAndSendMessageToTopic()
             throws ExecutionException, InterruptedException, SerializationException {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,7 +1,6 @@
 uk.gov.companieshouse.item-handler.health = /healthcheck
 
 spring.kafka.consumer.bootstrap-servers = ${spring.embedded.kafka.brokers}
-spring.kafka.consumer.auto-offset-reset = earliest
 kafka.topic.receiver = order-received
 
 uk.gov.companieshouse.item-handler.error-consumer = false


### PR DESCRIPTION
This removes the (redundant) resetting of countdown latch since clearing context for each test ensure that the latch is reset before the test. Also, removes the Spring property `spring.kafka.consumer.auto-offset-reset` as it doesn't seem to have any effect on the build quality.