### PR TITLE
Amend logging of Exception stack trace

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrdersKafkaConsumer.java
@@ -197,17 +197,15 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
             Exception exception) {
         Map<String, Object> logMap = LoggingUtils.getMessageHeadersAsMap(message);
         logMap.put(LoggingUtils.RETRY_ATTEMPT, attempt);
-        logMap.put(LoggingUtils.EXCEPTION, exception);
         LoggingUtils.getLogger().error("'order-received' message processing failed with a recoverable exception",
-                logMap);
+                exception, logMap);
     }
 
     protected void logMessageProcessingFailureNonRecoverable(
             org.springframework.messaging.Message<OrderReceived> message, Exception exception) {
         Map<String, Object> logMap = LoggingUtils.getMessageHeadersAsMap(message);
-        logMap.put(LoggingUtils.EXCEPTION, exception);
         LoggingUtils.getLogger().error("order-received message processing failed with a non-recoverable exception",
-                logMap);
+                exception, logMap);
     }
 
     private void logMessageProcessed(org.springframework.messaging.Message<OrderReceived> message,
@@ -228,9 +226,8 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
         try {
             kafkaProducer.sendMessage(createRetryMessage(orderUri, nextTopic));
         } catch (ExecutionException | InterruptedException e) {
-            logMap.put(LoggingUtils.EXCEPTION, e);
             LoggingUtils.getLogger().error(String.format("Error sending message: \"%1$s\" to topic: \"%2$s\"",
-                    orderUri, nextTopic), logMap);
+                    orderUri, nextTopic), e, logMap);
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
@@ -252,9 +249,8 @@ public class OrdersKafkaConsumer implements ConsumerSeekAware {
             LoggingUtils.logIfNotNull(logMap, LoggingUtils.MESSAGE, orderUri);
             LoggingUtils.logIfNotNull(logMap, LoggingUtils.TOPIC, topic);
             LoggingUtils.logIfNotNull(logMap, LoggingUtils.OFFSET, message.getOffset());
-            logMap.put(LoggingUtils.EXCEPTION, e);
             LoggingUtils.getLogger().error(String.format("Error serializing message: \"%1$s\" for topic: \"%2$s\"",
-                    orderUri, topic), logMap);
+                    orderUri, topic), e, logMap);
         }
         message.setTopic(topic);
         message.setTimestamp(new Date().getTime());

--- a/src/main/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtils.java
@@ -21,7 +21,6 @@ public class LoggingUtils {
     public static final String KEY = "key";
     public static final String PARTITION = "partition";
     public static final String RETRY_ATTEMPT = "retry_attempt";
-    public static final String EXCEPTION = "exception";
     public static final String MESSAGE = "message";
     public static final String CURRENT_TOPIC = "current_topic";
     public static final String NEXT_TOPIC = "next_topic";

--- a/src/main/java/uk/gov/companieshouse/itemhandler/service/OrderProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/service/OrderProcessorService.java
@@ -38,8 +38,7 @@ public class OrderProcessorService {
             LoggingUtils.getLogger().info("Processing order received", logMap);
             emailer.sendCertificateOrderConfirmation(order);
         } catch (Exception ex) {
-            logMap.put(LoggingUtils.EXCEPTION, ex);
-            LoggingUtils.getLogger().error("Exception caught getting order data.", logMap);
+            LoggingUtils.getLogger().error("Exception caught getting order data.", ex, logMap);
         }
 
     }


### PR DESCRIPTION
Removed occurrences of exception objects being included in the Map for logging, instead log the stack trace as text instead of as JSON 
Removed EXCEPTION logging key from LoggingUtils as no longer used

Amendments made for GCI-1311.