### PR TITLE
GCI-1612: Handle optional fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<private-api-sdk-java.version>2.0.57</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.1.48</api-sdk-java.version>
-		<kafka-models.version>1.0.16</kafka-models.version>
+		<kafka-models.version>1.0.17</kafka-models.version>
 		<ch-kafka.version>1.4.2</ch-kafka.version>
 		<snakeyaml.version>1.25</snakeyaml.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/ChdItemOrderedAvroSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/ChdItemOrderedAvroSerializerTest.java
@@ -1,0 +1,183 @@
+package uk.gov.companieshouse.itemhandler.kafka;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+import uk.gov.companieshouse.orders.items.ChdItemOrdered;
+import uk.gov.companieshouse.orders.items.DeliveryDetails;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static uk.gov.companieshouse.itemhandler.util.TestUtils.createAvroOrder;
+import static uk.gov.companieshouse.itemhandler.util.TestUtils.createDeliveryDetails;
+
+/**
+ * Unit tests {@link uk.gov.companieshouse.kafka.serialization.AvroSerializer} for
+ * {@link uk.gov.companieshouse.orders.items.ChdItemOrdered} to verify whether fields are handled as optional
+ * within the ChdItemOrdered Avro schema.
+ */
+@ExtendWith(MockitoExtension.class)
+class ChdItemOrderedAvroSerializerTest {
+
+    final AvroSerializer<ChdItemOrdered> serializerUnderTest =
+            new SerializerFactory().getGenericRecordSerializer(ChdItemOrdered.class);
+
+    @Test
+    @DisplayName("toBinary throws a NullPointerException if mandatory field reference value is absent")
+    void toBinaryNullPaymentReferencNullPointerException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.setReference(null);
+
+        // When and then
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() ->
+                serializerUnderTest.toBinary(order))
+                .withMessage("null of string in field reference of uk.gov.companieshouse.orders.items.ChdItemOrdered")
+                .withCause(new NullPointerException());
+
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional payment_reference gracefully")
+    void toBinaryNullPaymentReferenceThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.setPaymentReference(null);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional company_name gracefully")
+    void toBinaryNullCompanyNameThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.getItem().setCompanyName(null);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional company_number gracefully")
+    void toBinaryNullCompanyNumberThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.getItem().setCompanyNumber(null);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional customer_reference gracefully")
+    void toBinaryNullCustomerReferenceThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.getItem().setCustomerReference(null);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional description_identifier gracefully")
+    void toBinaryNullDescriptionIdentifierThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.getItem().setDescriptionIdentifier(null);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional description_values gracefully")
+    void toBinaryNullDescriptionValuesThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.getItem().setDescriptionValues(null);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional discount_applied gracefully")
+    void toBinaryNullDiscountAppliedThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.getItem().getItemCosts().get(0).setDiscountApplied(null);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional delivery_details gracefully")
+    void toBinaryNullDeliveryDetailsThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        order.setDeliveryDetails(null);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional address_line_2 gracefully")
+    void toBinaryNullAddressLine2ThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        final DeliveryDetails details = createDeliveryDetails();
+        details.setAddressLine2(null);
+        order.setDeliveryDetails(details);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional po_box gracefully")
+    void toBinaryNullPoBoxThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        final DeliveryDetails details = createDeliveryDetails();
+        details.setPoBox(null);
+        order.setDeliveryDetails(details);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional postal_code gracefully")
+    void toBinaryNullPostalCodeThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        final DeliveryDetails details = createDeliveryDetails();
+        details.setPostalCode(null);
+        order.setDeliveryDetails(details);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+    @Test
+    @DisplayName("toBinary handles absence of optional region gracefully")
+    void toBinaryNullRegionThrowsNoException() {
+        // Given
+        final ChdItemOrdered order = createAvroOrder();
+        final DeliveryDetails details = createDeliveryDetails();
+        details.setRegion(null);
+        order.setDeliveryDetails(details);
+
+        // When and then
+        assertAll(() -> serializerUnderTest.toBinary(order));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/ChdItemOrderedAvroSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/ChdItemOrderedAvroSerializerTest.java
@@ -2,8 +2,6 @@ package uk.gov.companieshouse.itemhandler.kafka;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
 import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
 import uk.gov.companieshouse.orders.items.ChdItemOrdered;
@@ -19,7 +17,6 @@ import static uk.gov.companieshouse.itemhandler.util.TestUtils.createDeliveryDet
  * {@link uk.gov.companieshouse.orders.items.ChdItemOrdered} to verify whether fields are handled as optional
  * within the ChdItemOrdered Avro schema.
  */
-@ExtendWith(MockitoExtension.class)
 class ChdItemOrderedAvroSerializerTest {
 
     final AvroSerializer<ChdItemOrdered> serializerUnderTest =

--- a/src/test/java/uk/gov/companieshouse/itemhandler/util/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/util/TestUtils.java
@@ -6,6 +6,10 @@ import uk.gov.companieshouse.itemhandler.model.ItemCosts;
 import uk.gov.companieshouse.itemhandler.model.ItemLinks;
 import uk.gov.companieshouse.itemhandler.model.MissingImageDeliveryItemOptions;
 import uk.gov.companieshouse.itemhandler.model.OrderData;
+import uk.gov.companieshouse.orders.items.ChdItemOrdered;
+import uk.gov.companieshouse.orders.items.DeliveryDetails;
+import uk.gov.companieshouse.orders.items.Links;
+import uk.gov.companieshouse.orders.items.OrderedBy;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -57,5 +61,73 @@ public class TestUtils {
         order.setTotalOrderCost("3");
         return order;
     }
+
+    /**
+     * Creates a valid single MID item order with all the required fields populated.
+     * @return a fully populated {@link ChdItemOrdered} object
+     */
+    public static ChdItemOrdered createAvroOrder() {
+        final ChdItemOrdered order = new ChdItemOrdered();
+        final uk.gov.companieshouse.orders.items.Item item = new uk.gov.companieshouse.orders.items.Item();
+        item.setId(MISSING_IMAGE_DELIVERY_ITEM_ID);
+        order.setItem(item);
+        order.setOrderedAt(LocalDateTime.now().toString());
+        final OrderedBy orderedBy = new OrderedBy();
+        orderedBy.setEmail("demo@ch.gov.uk");
+        orderedBy.setId("4Y2VkZWVlMzhlZWFjY2M4MzQ3M1234");
+        order.setOrderedBy(orderedBy);
+        final uk.gov.companieshouse.orders.items.ItemCosts costs = new uk.gov.companieshouse.orders.items.ItemCosts("0", "3", "3", "missing-image-delivery-accounts");
+        item.setItemCosts(singletonList(costs));
+        final Map<String, String> options = new HashMap<>();
+        options.put("filingHistoryDescriptionValues",
+                "{\"change_date\":\"2010-02-12\",\"officer_name\":\"Thomas David Wheare\"}");
+        options.put("filingHistoryCategory", "officers");
+        options.put("filingHistoryDate", "2010-02-12");
+        options.put("filingHistoryDescription", "change-person-director-company-with-change-date");
+        options.put("filingHistoryId", "MzAwOTM2MDg5OWFkaXF6a2N4");
+        options.put("filingHistoryType", "CH01");
+        item.setItemOptions(options);
+        final Links links = new Links();
+        links.setSelf("/orderable/missing-image-deliveries/MID-535516-028321");
+        item.setLinks(links);
+        item.setQuantity(1);
+        item.setCompanyName("THE GIRLS' DAY SCHOOL TRUST");
+        item.setCompanyNumber("00006400");
+        item.setCustomerReference("MID ordered by VJ GCI-1301");
+        item.setDescription("missing image delivery for company 00006400");
+        item.setDescriptionIdentifier("missing-image-delivery");
+        final Map<String, String> descriptionValues = new HashMap<>();
+        descriptionValues.put("company_number", "00006400");
+        descriptionValues.put("missing-image-delivery", "missing image delivery for company 00006400");
+        item.setDescriptionValues(descriptionValues);
+        item.setItemUri("/orderable/missing-image-deliveries/MID-535516-028321");
+        item.setKind("item#missing-image-delivery");
+        item.setTotalItemCost("3");
+        item.setPostageCost("0");
+        order.setPaymentReference("1234");
+        order.setReference(ORDER_REFERENCE);
+        order.setTotalOrderCost("3");
+        return order;
+    }
+
+    /**
+     * Create a fully populated {@link DeliveryDetails} object for testing.
+     * @return the full delivery details object
+     */
+    public static DeliveryDetails createDeliveryDetails() {
+
+        final DeliveryDetails delivery = new DeliveryDetails();
+        delivery.setForename("Jenny");
+        delivery.setSurname("Wilson");
+        delivery.setAddressLine1("Kemp House Capital Office");
+        delivery.setAddressLine2("152-160 City Road");
+        delivery.setLocality("Kemp House");
+        delivery.setPoBox("PO Box");
+        delivery.setRegion("London");
+        delivery.setPostalCode("EC1V 2NX");
+        delivery.setCountry("England");
+        return delivery;
+    }
+
 
 }


### PR DESCRIPTION
* Test Avro serialisation of optional fields in the absence of values for those fields. 
* Bring in updated Avro schema generated model classes.