### PR TITLE
DEBT-1451 Updating to use latest log4j 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,17 +196,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updating to use latest log4j 2.16.0 security fixes

▶ mvn dependency:tree | grep log4j                  
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile
[INFO] +- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
[INFO] \- org.apache.logging.log4j:log4j-to-slf4j:jar:2.16.0:compile
