### PR TITLE
BI-9947 Fix test synchronisation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderProcessResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderProcessResponseHandler.java
@@ -43,13 +43,13 @@ class OrderProcessResponseHandler implements OrderProcessResponse.Visitor {
         logger.error("order-received message processing failed with a non-recoverable exception", LoggingUtils.getMessageHeadersAsMap(message));
     }
 
-    protected void publishToRetryTopic(Message<OrderReceived> message, OrderReceived payload) {
+    private void publishToRetryTopic(Message<OrderReceived> message, OrderReceived payload) {
         logger.info("order-received message processing failed with a recoverable exception", LoggingUtils.getMessageHeadersAsMap(message));
         payload.setAttempt(payload.getAttempt() + 1);
         messageProducer.sendMessage(payload, config.getRetryTopic());
     }
 
-    protected void publishToErrorTopic(Message<OrderReceived> message, OrderReceived payload) {
+    private void publishToErrorTopic(Message<OrderReceived> message, OrderReceived payload) {
         logger.info("order-received message processing failed; maximum number of retry attempts exceeded", LoggingUtils.getMessageHeadersAsMap(message));
         payload.setAttempt(0);
         messageProducer.sendMessage(payload, config.getErrorTopic());

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderProcessResponseHandlerAspect.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderProcessResponseHandlerAspect.java
@@ -11,24 +11,24 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class OrderProcessResponseHandlerAspect {
-    private CountDownLatch postPublishToErrorTopicLatch;
+    private CountDownLatch postServiceUnavailableLatch;
 
-    @Pointcut("execution(private void uk.gov.companieshouse.itemhandler.kafka.OrderProcessResponseHandler.publishToErrorTopic(..))")
-    private void publishToErrorTopic() {
+    @Pointcut("execution(public void uk.gov.companieshouse.itemhandler.kafka.OrderProcessResponseHandler.serviceUnavailable(..))")
+    void serviceUnavailable() {
     }
 
-    @After("publishToErrorTopic()")
-    private void afterPublishToErrorTopic() {
-        if (!isNull(postPublishToErrorTopicLatch)) {
-            postPublishToErrorTopicLatch.countDown();
+    @After("serviceUnavailable()")
+    void afterServiceUnavailable() {
+        if (!isNull(postServiceUnavailableLatch)) {
+            postServiceUnavailableLatch.countDown();
         }
     }
 
-    CountDownLatch getPostPublishToErrorTopicLatch() {
-        return postPublishToErrorTopicLatch;
+    CountDownLatch getPostServiceUnavailableLatch() {
+        return postServiceUnavailableLatch;
     }
 
-    void setPostPublishToErrorTopicLatch(CountDownLatch postPublishToErrorTopicLatch) {
-        this.postPublishToErrorTopicLatch = postPublishToErrorTopicLatch;
+    void setPostServiceUnavailableLatch(CountDownLatch postServiceUnavailableLatch) {
+        this.postServiceUnavailableLatch = postServiceUnavailableLatch;
     }
 }


### PR DESCRIPTION
* Ensure AOP can intercept call by using top level method in point cut expression

Relates to: [Fix issues with Kafka resilience in Item Handler](https://companieshouse.atlassian.net/browse/BI-9947)