### PR TITLE
BI-9948 Correct retry and error topic naming in configuration

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/KafkaConfig.java
@@ -29,7 +29,7 @@ public class KafkaConfig {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
-    @Value("${kafka.topics.order-received-notification-error-group}")
+    @Value("${kafka.topics.order-received-error-group}")
     private String orderReceivedErrorGroup;
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/KafkaTopics.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/KafkaTopics.java
@@ -3,8 +3,8 @@ package uk.gov.companieshouse.itemhandler.kafka;
 public class KafkaTopics {
     private String emailSend;
     private String orderReceived;
-    private String orderReceivedNotificationRetry;
-    private String orderReceivedNotificationError;
+    private String orderReceivedRetry;
+    private String orderReceivedError;
     private String chdItemOrdered;
 
     public void setEmailSend(String emailSend) {
@@ -15,12 +15,12 @@ public class KafkaTopics {
         this.orderReceived = orderReceived;
     }
 
-    public void setOrderReceivedNotificationRetry(String orderReceivedNotificationRetry) {
-        this.orderReceivedNotificationRetry = orderReceivedNotificationRetry;
+    public void setOrderReceivedRetry(String orderReceivedRetry) {
+        this.orderReceivedRetry = orderReceivedRetry;
     }
 
-    public void setOrderReceivedNotificationError(String orderReceivedNotificationError) {
-        this.orderReceivedNotificationError = orderReceivedNotificationError;
+    public void setOrderReceivedError(String orderReceivedError) {
+        this.orderReceivedError = orderReceivedError;
     }
 
     public void setChdItemOrdered(String chdItemOrdered) {
@@ -35,12 +35,12 @@ public class KafkaTopics {
         return orderReceived;
     }
 
-    public String getOrderReceivedNotificationRetry() {
-        return orderReceivedNotificationRetry;
+    public String getOrderReceivedRetry() {
+        return orderReceivedRetry;
     }
 
-    public String getOrderReceivedNotificationError() {
-        return orderReceivedNotificationError;
+    public String getOrderReceivedError() {
+        return orderReceivedError;
     }
 
     public String getChdItemOrdered() {

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageErrorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageErrorConsumer.java
@@ -32,9 +32,9 @@ public class OrderMessageErrorConsumer {
     private final OrderProcessResponseHandler orderProcessResponseHandler;
     private final Logger logger;
 
-    @Value("${kafka.topics.order-received-notification-error-group}")
+    @Value("${kafka.topics.order-received-error-group}")
     private String errorGroup;
-    @Value("${kafka.topics.order-received-notification-error}")
+    @Value("${kafka.topics.order-received-error}")
     private String errorTopic;
 
     public OrderMessageErrorConsumer(KafkaListenerEndpointRegistry registry,
@@ -59,9 +59,9 @@ public class OrderMessageErrorConsumer {
      *
      * @param message
      */
-    @KafkaListener(id = "#{'${kafka.topics.order-received-notification-error-group}'}",
-            groupId = "#{'${kafka.topics.order-received-notification-error-group}'}",
-            topics = "#{'${kafka.topics.order-received-notification-error}'}",
+    @KafkaListener(id = "#{'${kafka.topics.order-received-error-group}'}",
+            groupId = "#{'${kafka.topics.order-received-error-group}'}",
+            topics = "#{'${kafka.topics.order-received-error}'}",
             autoStartup = "#{${uk.gov.companieshouse.item-handler.error-consumer}}",
             containerFactory = "kafkaListenerContainerFactory")
     public void processOrderReceived(

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageHandler.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageHandler.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.itemhandler.kafka;
 
-import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemhandler.logging.LoggingUtils;
 import uk.gov.companieshouse.itemhandler.service.OrderProcessResponse;

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageRetryConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageRetryConsumer.java
@@ -19,9 +19,9 @@ public class OrderMessageRetryConsumer {
      *
      * @param message received
      */
-    @KafkaListener(id = "#{'${kafka.topics.order-received-notification-retry-group}'}",
-            groupId = "#{'${kafka.topics.order-received-notification-retry-group}'}",
-            topics = "#{'${kafka.topics.order-received-notification-retry}'}",
+    @KafkaListener(id = "#{'${kafka.topics.order-received-retry-group}'}",
+            groupId = "#{'${kafka.topics.order-received-retry-group}'}",
+            topics = "#{'${kafka.topics.order-received-retry}'}",
             autoStartup = "#{!${uk.gov.companieshouse.item-handler.error-consumer}}",
             containerFactory = "kafkaListenerContainerFactory")
     public void processOrderReceived(Message<OrderReceived> message) {

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderProcessResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderProcessResponseHandler.java
@@ -44,14 +44,14 @@ class OrderProcessResponseHandler implements OrderProcessResponse.Visitor {
     }
 
     private void publishToRetryTopic(Message<OrderReceived> message, OrderReceived payload) {
-        logger.info("order-received message processing failed with a recoverable exception", LoggingUtils.getMessageHeadersAsMap(message));
         payload.setAttempt(payload.getAttempt() + 1);
+        logger.info("publish order received to retry topic", LoggingUtils.getMessageHeadersAsMap(message));
         messageProducer.sendMessage(payload, config.getRetryTopic());
     }
 
     private void publishToErrorTopic(Message<OrderReceived> message, OrderReceived payload) {
-        logger.info("order-received message processing failed; maximum number of retry attempts exceeded", LoggingUtils.getMessageHeadersAsMap(message));
         payload.setAttempt(0);
+        logger.info("publish order received to error topic", LoggingUtils.getMessageHeadersAsMap(message));
         messageProducer.sendMessage(payload, config.getErrorTopic());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtils.java
@@ -101,6 +101,7 @@ public class LoggingUtils {
         logIfNotNull(logMap, OFFSET, messageHeaders.get(KafkaHeaders.OFFSET));
         logIfNotNull(logMap, PARTITION, messageHeaders.get(KafkaHeaders.RECEIVED_PARTITION_ID));
         logIfNotNull(logMap, RETRY_ATTEMPT, message.getPayload().getAttempt());
+        logIfNotNull(logMap, ORDER_URI, message.getPayload().getOrderUri());
 
         return logMap;
     }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtils.java
@@ -100,6 +100,7 @@ public class LoggingUtils {
         logIfNotNull(logMap, TOPIC, messageHeaders.get(KafkaHeaders.RECEIVED_TOPIC));
         logIfNotNull(logMap, OFFSET, messageHeaders.get(KafkaHeaders.OFFSET));
         logIfNotNull(logMap, PARTITION, messageHeaders.get(KafkaHeaders.RECEIVED_PARTITION_ID));
+        logIfNotNull(logMap, RETRY_ATTEMPT, message.getPayload().getAttempt());
 
         return logMap;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,13 +18,13 @@ application-namespace=item-handler
 kafka.topics.email-send=email-send
 kafka.topics.order-received=order-received
 kafka.topics.order-received_group=${application-namespace}-${kafka.topics.order-received}
-kafka.topics.order-received-notification-retry=order-received-retry
-kafka.topics.order-received-notification-retry-group=${application-namespace}-${kafka.topics.order-received-notification-retry}
-kafka.topics.order-received-notification-error=order-received-error
-kafka.topics.order-received-notification-error-group=${application-namespace}-${kafka.topics.order-received-notification-error}
+kafka.topics.order-received-retry=order-received-retry
+kafka.topics.order-received-retry-group=${application-namespace}-${kafka.topics.order-received-retry}
+kafka.topics.order-received-error=order-received-error
+kafka.topics.order-received-error-group=${application-namespace}-${kafka.topics.order-received-error}
 kafka.topics.chd-item-ordered=chd-item-ordered
 
 # Order process response handler
-response.handler.maximumRetryAttempts = 1
-response.handler.retryTopic = ${kafka.topics.order-received-notification-retry}
-response.handler.errorTopic = ${kafka.topics.order-received-notification-error}
+response.handler.maximumRetryAttempts = 5
+response.handler.retryTopic = ${kafka.topics.order-received-retry}
+response.handler.errorTopic = ${kafka.topics.order-received-error}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,13 +18,13 @@ application-namespace=item-handler
 kafka.topics.email-send=email-send
 kafka.topics.order-received=order-received
 kafka.topics.order-received_group=${application-namespace}-${kafka.topics.order-received}
-kafka.topics.order-received-notification-retry=order-received-notification-retry
+kafka.topics.order-received-notification-retry=order-received-retry
 kafka.topics.order-received-notification-retry-group=${application-namespace}-${kafka.topics.order-received-notification-retry}
-kafka.topics.order-received-notification-error=order-received-notification-error
+kafka.topics.order-received-notification-error=order-received-error
 kafka.topics.order-received-notification-error-group=${application-namespace}-${kafka.topics.order-received-notification-error}
 kafka.topics.chd-item-ordered=chd-item-ordered
 
 # Order process response handler
-response.handler.maximumRetryAttempts = 5
+response.handler.maximumRetryAttempts = 1
 response.handler.retryTopic = ${kafka.topics.order-received-notification-retry}
 response.handler.errorTopic = ${kafka.topics.order-received-notification-error}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/config/EmbeddedKafkaBrokerConfiguration.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/config/EmbeddedKafkaBrokerConfiguration.java
@@ -13,7 +13,6 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Scope;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import uk.gov.companieshouse.itemhandler.kafka.KafkaTopics;
@@ -47,7 +46,7 @@ public class EmbeddedKafkaBrokerConfiguration {
         KafkaConsumer<String, OrderReceived> kafkaConsumer = new KafkaConsumer<>(props,
                 new StringDeserializer(),
                 new MessageDeserialiser<>(OrderReceived.class));
-        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(kafkaConsumer, kafkaTopics.getOrderReceivedNotificationRetry());
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(kafkaConsumer, kafkaTopics.getOrderReceivedRetry());
         return kafkaConsumer;
     }
 
@@ -57,7 +56,7 @@ public class EmbeddedKafkaBrokerConfiguration {
         KafkaConsumer<String, OrderReceived> kafkaConsumer = new KafkaConsumer<>(props,
                 new StringDeserializer(),
                 new MessageDeserialiser<>(OrderReceived.class));
-        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(kafkaConsumer, kafkaTopics.getOrderReceivedNotificationError());
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(kafkaConsumer, kafkaTopics.getOrderReceivedError());
         return kafkaConsumer;
     }
 

--- a/src/test/java/uk/gov/companieshouse/itemhandler/config/KafkaTopicInitialiser.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/config/KafkaTopicInitialiser.java
@@ -17,8 +17,8 @@ public class KafkaTopicInitialiser implements InitializingBean {
     public void afterPropertiesSet() throws Exception {
         broker.addTopics(new NewTopic(kafkaTopics.getEmailSend(), 1, (short) 1));
         broker.addTopics(new NewTopic(kafkaTopics.getOrderReceived(), 1, (short) 1));
-        broker.addTopics(new NewTopic(kafkaTopics.getOrderReceivedNotificationRetry(), 1, (short) 1));
-        broker.addTopics(new NewTopic(kafkaTopics.getOrderReceivedNotificationError(), 1, (short) 1));
+        broker.addTopics(new NewTopic(kafkaTopics.getOrderReceivedRetry(), 1, (short) 1));
+        broker.addTopics(new NewTopic(kafkaTopics.getOrderReceivedError(), 1, (short) 1));
         broker.addTopics(new NewTopic(kafkaTopics.getChdItemOrdered(), 1, (short) 1));
     }
 

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageConsumerTest.java
@@ -1,11 +1,9 @@
 package uk.gov.companieshouse.itemhandler.kafka;
 
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import ch.qos.logback.classic.turbo.DuplicateMessageFilter;
 import java.util.HashMap;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
@@ -68,7 +66,7 @@ class OrderMessageConsumerTest {
         orderMessageHandler.handleMessage(createTestMessage());
 
         // Then
-        verify(orderProcessResponseHandler, times(1)).serviceOk(any());
+        verify(orderProcessResponseHandler).serviceOk(any());
     }
 
     @Test
@@ -83,7 +81,7 @@ class OrderMessageConsumerTest {
         orderMessageHandler.handleMessage(createTestMessage());
 
         // Then
-        verify(orderProcessResponseHandler, times(1)).serviceUnavailable(any());
+        verify(orderProcessResponseHandler).serviceUnavailable(any());
     }
 
     @Test
@@ -98,6 +96,6 @@ class OrderMessageConsumerTest {
         orderMessageHandler.handleMessage(createTestMessage());
 
         // Then
-        verify(orderProcessResponseHandler, times(1)).serviceError(any());
+        verify(orderProcessResponseHandler).serviceError(any());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageConsumerTest.java
@@ -5,53 +5,53 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.turbo.DuplicateMessageFilter;
 import java.util.HashMap;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.MessageHeaders;
 import uk.gov.companieshouse.itemhandler.service.OrderProcessResponse;
 import uk.gov.companieshouse.itemhandler.service.OrderProcessorService;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.orders.OrderReceived;
 
 @ExtendWith(MockitoExtension.class)
 class OrderMessageConsumerTest {
     private static final String ORDER_RECEIVED_URI = "/order/ORDER-12345";
-    private static final String ORDER_RECEIVED_TOPIC = "order-received";
     private static final String ORDER_RECEIVED_KEY = "order-received";
     private static final String ORDER_RECEIVED_TOPIC_RETRY = "order-received-retry";
-    private static final String ORDER_RECEIVED_TOPIC_ERROR = "order-received-error";
 
-    @Spy
-    @InjectMocks
-    private OrderMessageHandler orderMessageHandler;
     @Mock
     private OrderProcessorService orderProcessorService;
     @Mock
     private OrderProcessResponseHandler orderProcessResponseHandler;
+    @Mock
+    private Logger logger;
+    @InjectMocks
+    private OrderMessageHandler orderMessageHandler;
 
-    private static org.springframework.messaging.Message<OrderReceived> createTestMessage(String receivedTopic) {
+    private static org.springframework.messaging.Message<OrderReceived> createTestMessage() {
         return new org.springframework.messaging.Message<OrderReceived>() {
             @Override
-            public OrderReceived getPayload() {
+            public @NotNull OrderReceived getPayload() {
                 OrderReceived orderReceived = new OrderReceived();
                 orderReceived.setOrderUri(ORDER_RECEIVED_URI);
                 return orderReceived;
             }
 
             @Override
-            public MessageHeaders getHeaders() {
+            public @NotNull MessageHeaders getHeaders() {
                 Map<String, Object> headerItems = new HashMap<>();
-                headerItems.put("kafka_receivedTopic", receivedTopic);
+                headerItems.put("kafka_receivedTopic", OrderMessageConsumerTest.ORDER_RECEIVED_TOPIC_RETRY);
                 headerItems.put("kafka_offset", 0);
                 headerItems.put("kafka_receivedMessageKey", ORDER_RECEIVED_KEY);
                 headerItems.put("kafka_receivedPartitionId", 0);
-                MessageHeaders headers = new MessageHeaders(headerItems);
-                return headers;
+                return new MessageHeaders(headerItems);
             }
         };
     }
@@ -65,7 +65,7 @@ class OrderMessageConsumerTest {
                 .build());
 
         // When
-        orderMessageHandler.handleMessage(createTestMessage(ORDER_RECEIVED_TOPIC_RETRY));
+        orderMessageHandler.handleMessage(createTestMessage());
 
         // Then
         verify(orderProcessResponseHandler, times(1)).serviceOk(any());
@@ -80,7 +80,7 @@ class OrderMessageConsumerTest {
                 .build());
 
         // When
-        orderMessageHandler.handleMessage(createTestMessage(ORDER_RECEIVED_TOPIC_RETRY));
+        orderMessageHandler.handleMessage(createTestMessage());
 
         // Then
         verify(orderProcessResponseHandler, times(1)).serviceUnavailable(any());
@@ -95,7 +95,7 @@ class OrderMessageConsumerTest {
                 .build());
 
         // When
-        orderMessageHandler.handleMessage(createTestMessage(ORDER_RECEIVED_TOPIC_RETRY));
+        orderMessageHandler.handleMessage(createTestMessage());
 
         // Then
         verify(orderProcessResponseHandler, times(1)).serviceError(any());

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageDefaultConsumerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageDefaultConsumerIntegrationTest.java
@@ -51,8 +51,6 @@ import uk.gov.companieshouse.orders.items.ChdItemOrdered;
         properties={"uk.gov.companieshouse.item-handler.error-consumer=false"})
 class OrderMessageDefaultConsumerIntegrationTest {
 
-    public static final String ORDER_REFERENCE_NUMBER = "87654321";
-    public static final String ORDER_NOTIFICATION_REFERENCE = "/orders/" + ORDER_REFERENCE_NUMBER;
     private static MockServerContainer container;
     private MockServerClient client;
 
@@ -97,12 +95,6 @@ class OrderMessageDefaultConsumerIntegrationTest {
         container.stop();
     }
 
-    private static OrderReceived getOrderReceived() {
-        OrderReceived orderReceived = new OrderReceived();
-        orderReceived.setOrderUri(ORDER_NOTIFICATION_REFERENCE);
-        return orderReceived;
-    }
-
     @BeforeEach
     void setup() {
         client = new MockServerClient(container.getHost(), container.getServerPort());
@@ -117,7 +109,7 @@ class OrderMessageDefaultConsumerIntegrationTest {
     void testConsumesCertificateOrderReceivedFromEmailSendTopic() throws ExecutionException, InterruptedException, IOException {
         //given
         client.when(request()
-                        .withPath(ORDER_NOTIFICATION_REFERENCE)
+                        .withPath(getOrderReference())
                         .withMethod(HttpMethod.GET.toString()))
                 .respond(response()
                         .withStatusCode(HttpStatus.OK.value())
@@ -149,7 +141,7 @@ class OrderMessageDefaultConsumerIntegrationTest {
     void testConsumesCertifiedDocumentOrderReceivedFromEmailSendTopic() throws ExecutionException, InterruptedException, IOException {
         // given
         client.when(request()
-                        .withPath(ORDER_NOTIFICATION_REFERENCE)
+                        .withPath(getOrderReference())
                         .withMethod(HttpMethod.GET.toString()))
                 .respond(response()
                         .withStatusCode(HttpStatus.OK.value())
@@ -180,7 +172,7 @@ class OrderMessageDefaultConsumerIntegrationTest {
     void testConsumesMissingImageDeliveryFromOrderReceivedAndPublishesChsItemOrdered() throws ExecutionException, InterruptedException, IOException {
         // given
         client.when(request()
-                        .withPath(ORDER_NOTIFICATION_REFERENCE)
+                        .withPath(getOrderReference())
                         .withMethod(HttpMethod.GET.toString()))
                 .respond(response()
                         .withStatusCode(HttpStatus.OK.value())
@@ -207,7 +199,7 @@ class OrderMessageDefaultConsumerIntegrationTest {
     void testLogAnErrorWhenOrdersApiReturnsOrderNotFound() throws ExecutionException, InterruptedException {
         //given
         client.when(request()
-                        .withPath(ORDER_NOTIFICATION_REFERENCE)
+                        .withPath(getOrderReference())
                         .withMethod(HttpMethod.GET.toString()))
                 .respond(response()
                         .withStatusCode(HttpStatus.NOT_FOUND.value()));
@@ -226,5 +218,15 @@ class OrderMessageDefaultConsumerIntegrationTest {
         verify(logger).error(argumentCaptor.capture(), anyMap());
         assertEquals("order-received message processing failed with a "
                 + "non-recoverable exception", argumentCaptor.getValue());
+    }
+
+    private OrderReceived getOrderReceived() {
+        OrderReceived orderReceived = new OrderReceived();
+        orderReceived.setOrderUri(getOrderReference());
+        return orderReceived;
+    }
+
+    private String getOrderReference() {
+        return "/orders/ORD-111111-123456";
     }
 }

--- a/src/test/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtilsTest.java
@@ -35,6 +35,8 @@ class LoggingUtilsTest {
 
     @Mock
     private RecordMetadata acknowledgedMessage;
+    @Mock
+    private OrderReceived orderReceived;
 
     @Test
     @DisplayName("createLogMap returns a new log map")
@@ -146,7 +148,7 @@ class LoggingUtilsTest {
         assertEquals(ORDER_REFERENCE, logMap.get(LoggingUtils.ORDER_REFERENCE_NUMBER));
         assertEquals(LOG_MESSAGE, logMap.get(LoggingUtils.MESSAGE));
     }
-    
+
     @Test
     @DisplayName("getMessageHeadersAsMap returns a populated map")
     void getMessageHeadersAsMapReturnsPopulatedMap() {
@@ -155,13 +157,16 @@ class LoggingUtilsTest {
         doReturn(TOPIC_VALUE).when(messageHeaders).get(KafkaHeaders.RECEIVED_TOPIC);
         doReturn(OFFSET_VALUE).when(messageHeaders).get(KafkaHeaders.OFFSET);
         doReturn(PARTITION_VALUE).when(messageHeaders).get(KafkaHeaders.RECEIVED_PARTITION_ID);
+        when(orderReceivedMessage.getPayload()).thenReturn(orderReceived);
+        when(orderReceived.getAttempt()).thenReturn(0);
         Map<String, Object> logMap = LoggingUtils.getMessageHeadersAsMap(orderReceivedMessage);
         assertNotNull(logMap);
-        assertEquals(4, logMap.size());
+        assertEquals(5, logMap.size());
         assertEquals(KEY_VALUE, logMap.get(LoggingUtils.KEY));
         assertEquals(TOPIC_VALUE, logMap.get(LoggingUtils.TOPIC));
         assertEquals(OFFSET_VALUE, logMap.get(LoggingUtils.OFFSET));
         assertEquals(PARTITION_VALUE, logMap.get(LoggingUtils.PARTITION));
+        assertEquals(0, logMap.get(LoggingUtils.RETRY_ATTEMPT));
     }
 
     private Message createMessageWithTopicAndOffset() {

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/OrdersApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/OrdersApiClientServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.itemhandler.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +75,7 @@ class OrdersApiClientServiceTest {
         // When & Then
         OrderData actualOrderData = serviceUnderTest.getOrderData(ORDER_URL);
         assertThat(actualOrderData.getEtag(), is(expectedOrderData.getEtag()));
-        verify(ordersApiToOrderDataMapper, times(1)).ordersApiToOrderData(ordersApi);
+        verify(ordersApiToOrderDataMapper).ordersApiToOrderData(ordersApi);
     }
 
     @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -16,9 +16,9 @@ application-namespace=item-handler
 kafka.topics.email-send=email-send
 kafka.topics.order-received=order-received
 kafka.topics.order-received_group=${application-namespace}-${kafka.topics.order-received}
-kafka.topics.order-received-notification-retry=order-received-notification-retry
+kafka.topics.order-received-notification-retry=order-received-retry
 kafka.topics.order-received-notification-retry-group=${application-namespace}-${kafka.topics.order-received-notification-retry}
-kafka.topics.order-received-notification-error=order-received-notification-error
+kafka.topics.order-received-notification-error=order-received-error
 kafka.topics.order-received-notification-error-group=${application-namespace}-${kafka.topics.order-received-notification-error}
 kafka.topics.chd-item-ordered=chd-item-ordered
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -16,13 +16,13 @@ application-namespace=item-handler
 kafka.topics.email-send=email-send
 kafka.topics.order-received=order-received
 kafka.topics.order-received_group=${application-namespace}-${kafka.topics.order-received}
-kafka.topics.order-received-notification-retry=order-received-retry
-kafka.topics.order-received-notification-retry-group=${application-namespace}-${kafka.topics.order-received-notification-retry}
-kafka.topics.order-received-notification-error=order-received-error
-kafka.topics.order-received-notification-error-group=${application-namespace}-${kafka.topics.order-received-notification-error}
+kafka.topics.order-received-retry=order-received-retry
+kafka.topics.order-received-retry-group=${application-namespace}-${kafka.topics.order-received-retry}
+kafka.topics.order-received-error=order-received-error
+kafka.topics.order-received-error-group=${application-namespace}-${kafka.topics.order-received-error}
 kafka.topics.chd-item-ordered=chd-item-ordered
 
 # Order process response handler
-response.handler.maximumRetryAttempts = 5
-response.handler.retryTopic = ${kafka.topics.order-received-notification-retry}
-response.handler.errorTopic = ${kafka.topics.order-received-notification-error}
+response.handler.maximumRetryAttempts = 2
+response.handler.retryTopic = ${kafka.topics.order-received-retry}
+response.handler.errorTopic = ${kafka.topics.order-received-error}


### PR DESCRIPTION
* Correct retry and error topic naming in configuration
* Improve logging output by adding attempt to response handler log output

Relates to: [BI-9948 Fix issues with Kafka resilience in Item Handler](https://companieshouse.atlassian.net/browse/BI-9947)