### PR TITLE
BI-9947 Enable processing in error recovery mode

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/ErrorConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/ErrorConsumerController.java
@@ -35,7 +35,7 @@ public class ErrorConsumerController {
         registry.getListenerContainer(errorGroup).pause();
     }
 
-    public void resumeConsumerThread() {
+    void resumeConsumerThread() {
         Map<String, Object> logMap = LoggingUtils.createLogMap();
         logMap.put(errorGroup, partitionOffset.getOffset());
         logMap.put(LoggingUtils.TOPIC, errorTopic);

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/ErrorConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/ErrorConsumerController.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.itemhandler.kafka;
+
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.itemhandler.logging.LoggingUtils;
+import uk.gov.companieshouse.logging.Logger;
+
+@Component
+public class ErrorConsumerController {
+    private final Logger logger;
+    private final String errorGroup;
+    private final String errorTopic;
+    private final PartitionOffset partitionOffset;
+    private final KafkaListenerEndpointRegistry registry;
+
+    public ErrorConsumerController(Logger logger,
+                                   @Value("${kafka.topics.order-received-error-group}") String errorGroup,
+                                   @Value("${kafka.topics.order-received-error}") String errorTopic,
+                                   PartitionOffset partitionOffset,
+                                   KafkaListenerEndpointRegistry registry) {
+        this.logger = logger;
+        this.errorGroup = errorGroup;
+        this.errorTopic = errorTopic;
+        this.partitionOffset = partitionOffset;
+        this.registry = registry;
+    }
+
+    public void pauseConsumerThread() {
+        Map<String, Object> logMap = LoggingUtils.createLogMap();
+        logMap.put(errorGroup, partitionOffset.getOffset());
+        logMap.put(LoggingUtils.TOPIC, errorTopic);
+        logger.info("Pausing error consumer as error recovery offset reached.", logMap);
+        registry.getListenerContainer(errorGroup).pause();
+    }
+
+    public void resumeConsumerThread() {
+        Map<String, Object> logMap = LoggingUtils.createLogMap();
+        logMap.put(errorGroup, partitionOffset.getOffset());
+        logMap.put(LoggingUtils.TOPIC, errorTopic);
+        logger.info("Resuming error consumer thread.", logMap);
+        registry.getListenerContainer(errorGroup).resume();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/ErrorConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/ErrorConsumerController.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.itemhandler.kafka;
 
 import java.util.Map;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.stereotype.Component;
@@ -32,7 +33,7 @@ public class ErrorConsumerController {
         logMap.put(errorGroup, partitionOffset.getOffset());
         logMap.put(LoggingUtils.TOPIC, errorTopic);
         logger.info("Pausing error consumer as error recovery offset reached.", logMap);
-        registry.getListenerContainer(errorGroup).pause();
+        Optional.ofNullable(registry.getListenerContainer(errorGroup)).ifPresent(c->c.pause());
     }
 
     void resumeConsumerThread() {
@@ -40,6 +41,6 @@ public class ErrorConsumerController {
         logMap.put(errorGroup, partitionOffset.getOffset());
         logMap.put(LoggingUtils.TOPIC, errorTopic);
         logger.info("Resuming error consumer thread.", logMap);
-        registry.getListenerContainer(errorGroup).resume();
+        Optional.ofNullable(registry.getListenerContainer(errorGroup)).ifPresent(c->c.resume());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/ErrorConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/ErrorConsumerController.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.itemhandler.logging.LoggingUtils;
 import uk.gov.companieshouse.logging.Logger;
@@ -33,7 +34,8 @@ public class ErrorConsumerController {
         logMap.put(errorGroup, partitionOffset.getOffset());
         logMap.put(LoggingUtils.TOPIC, errorTopic);
         logger.info("Pausing error consumer as error recovery offset reached.", logMap);
-        Optional.ofNullable(registry.getListenerContainer(errorGroup)).ifPresent(c->c.pause());
+        Optional.ofNullable(registry.getListenerContainer(errorGroup)).ifPresent(
+                MessageListenerContainer::pause);
     }
 
     void resumeConsumerThread() {
@@ -41,6 +43,7 @@ public class ErrorConsumerController {
         logMap.put(errorGroup, partitionOffset.getOffset());
         logMap.put(LoggingUtils.TOPIC, errorTopic);
         logger.info("Resuming error consumer thread.", logMap);
-        Optional.ofNullable(registry.getListenerContainer(errorGroup)).ifPresent(c->c.resume());
+        Optional.ofNullable(registry.getListenerContainer(errorGroup)).ifPresent(
+                MessageListenerContainer::resume);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/KafkaConfig.java
@@ -49,7 +49,6 @@ public class KafkaConfig {
         final Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, Boolean.toString(false));
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
         ConcurrentKafkaListenerContainerFactory<String, OrderReceived> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(getConsumerFactory(props));

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/KafkaConfig.java
@@ -33,12 +33,12 @@ public class KafkaConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, OrderReceived> kafkaListenerContainerFactory() {
-        return getContainerFactory(getDefaultConsumerProperties());
+        return getContainerFactory(getConsumerConfigs());
     }
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, OrderReceived> kafkaListenerContainerFactoryError() {
-        final Map<String, Object> props = getDefaultConsumerProperties();
+        final Map<String, Object> props = getConsumerConfigs();
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         return getContainerFactory(props);
     }
@@ -132,7 +132,7 @@ public class KafkaConfig {
         return factory;
     }
 
-    private Map<String, Object> getDefaultConsumerProperties() {
+    private Map<String, Object> getConsumerConfigs() {
         final Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, Boolean.toString(false));

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageErrorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageErrorConsumer.java
@@ -17,8 +17,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemhandler.logging.LoggingUtils;
-import uk.gov.companieshouse.itemhandler.service.OrderProcessResponse;
-import uk.gov.companieshouse.itemhandler.service.OrderProcessorService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.orders.OrderReceived;
 
@@ -28,9 +26,8 @@ public class OrderMessageErrorConsumer {
     private final PartitionOffset errorRecoveryOffset;
 
     private final KafkaListenerEndpointRegistry registry;
-    private final OrderProcessorService orderProcessorService;
-    private final OrderProcessResponseHandler orderProcessResponseHandler;
     private final Logger logger;
+    private final OrderMessageHandler orderReceivedProcessor;
 
     @Value("${kafka.topics.order-received-error-group}")
     private String errorGroup;
@@ -38,13 +35,11 @@ public class OrderMessageErrorConsumer {
     private String errorTopic;
 
     public OrderMessageErrorConsumer(KafkaListenerEndpointRegistry registry,
-                                     final OrderProcessorService orderProcessorService,
-                                     final OrderProcessResponseHandler orderProcessResponseHandler,
+                                     OrderMessageHandler orderReceivedProcessor,
                                      Logger logger,
                                      PartitionOffset errorRecoveryOffset) {
         this.registry = registry;
-        this.orderProcessorService = orderProcessorService;
-        this.orderProcessResponseHandler = orderProcessResponseHandler;
+        this.orderReceivedProcessor = orderReceivedProcessor;
         this.logger = logger;
         this.errorRecoveryOffset = errorRecoveryOffset;
     }
@@ -57,13 +52,15 @@ public class OrderMessageErrorConsumer {
      * is republished to `-retry` topic for failover processing. This listener stops accepting
      * messages when the topic's offset reaches `errorRecoveryOffset`.
      *
-     * @param message
+     * @param message to be processed
+     * @param offset Kafka offset of the current message
+     * @param consumer Kafka consumer used by current consumer thread
      */
     @KafkaListener(id = "#{'${kafka.topics.order-received-error-group}'}",
             groupId = "#{'${kafka.topics.order-received-error-group}'}",
             topics = "#{'${kafka.topics.order-received-error}'}",
             autoStartup = "#{${uk.gov.companieshouse.item-handler.error-consumer}}",
-            containerFactory = "kafkaListenerContainerFactory")
+            containerFactory = "kafkaListenerContainerFactoryError")
     public void processOrderReceived(
             Message<OrderReceived> message,
             @Header(KafkaHeaders.OFFSET) Long offset,
@@ -73,8 +70,11 @@ public class OrderMessageErrorConsumer {
         configureErrorRecoveryOffset(consumer);
 
         if (offset < errorRecoveryOffset.getOffset()) {
-            handleMessage(message);
-        } else {
+            orderReceivedProcessor.handleMessage(message);
+        }
+
+        // Stop consumer after last message processed
+        if (offset >= errorRecoveryOffset.getOffset() - 1) {
             Map<String, Object> logMap = LoggingUtils.createLogMap();
             logMap.put(errorGroup, errorRecoveryOffset);
             logMap.put(LoggingUtils.TOPIC, errorTopic);
@@ -92,29 +92,6 @@ public class OrderMessageErrorConsumer {
                         errorRecoveryOffset.clear();
                     }
                 });
-    }
-
-    /**
-     * Handles processing of received message.
-     *
-     * @param message containing order received
-     */
-    protected void handleMessage(org.springframework.messaging.Message<OrderReceived> message) {
-        OrderReceived orderReceived = message.getPayload();
-        String orderReceivedUri = orderReceived.getOrderUri();
-        logMessageReceived(message, orderReceivedUri);
-
-        // Process message
-        OrderProcessResponse response = orderProcessorService.processOrderReceived(orderReceivedUri);
-        // Handle response
-        response.getStatus().accept(orderProcessResponseHandler, message);
-    }
-
-    protected void logMessageReceived(org.springframework.messaging.Message<OrderReceived> message,
-                                      String orderUri) {
-        Map<String, Object> logMap = LoggingUtils.getMessageHeadersAsMap(message);
-        LoggingUtils.logIfNotNull(logMap, LoggingUtils.ORDER_URI, orderUri);
-        logger.info("'order-received' message received", logMap);
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageRetryConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageRetryConsumer.java
@@ -22,7 +22,7 @@ public class OrderMessageRetryConsumer {
     @KafkaListener(id = "#{'${kafka.topics.order-received-retry-group}'}",
             groupId = "#{'${kafka.topics.order-received-retry-group}'}",
             topics = "#{'${kafka.topics.order-received-retry}'}",
-            autoStartup = "true",
+            autoStartup = "#{!${uk.gov.companieshouse.item-handler.error-consumer}}",
             containerFactory = "kafkaListenerContainerFactory")
     public void processOrderReceived(Message<OrderReceived> message) {
         orderReceivedProcessor.handleMessage(message);

--- a/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageRetryConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageRetryConsumer.java
@@ -22,7 +22,7 @@ public class OrderMessageRetryConsumer {
     @KafkaListener(id = "#{'${kafka.topics.order-received-retry-group}'}",
             groupId = "#{'${kafka.topics.order-received-retry-group}'}",
             topics = "#{'${kafka.topics.order-received-retry}'}",
-            autoStartup = "#{!${uk.gov.companieshouse.item-handler.error-consumer}}",
+            autoStartup = "true",
             containerFactory = "kafkaListenerContainerFactory")
     public void processOrderReceived(Message<OrderReceived> message) {
         orderReceivedProcessor.handleMessage(message);

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageErrorConsumerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageErrorConsumerIntegrationTest.java
@@ -69,6 +69,9 @@ class OrderMessageErrorConsumerIntegrationTest {
     @Autowired
     private PartitionOffset errorRecoveryOffset;
 
+    @Autowired
+    private ErrorConsumerController errorConsumerController;
+
     @BeforeAll
     static void before() {
         container = new MockServerContainer(DockerImageName.parse(
@@ -90,6 +93,7 @@ class OrderMessageErrorConsumerIntegrationTest {
     void setup() {
         client = new MockServerClient(container.getHost(), container.getServerPort());
         errorRecoveryOffset.reset();
+        errorConsumerController.resumeConsumerThread();
     }
 
     @AfterEach
@@ -223,7 +227,7 @@ class OrderMessageErrorConsumerIntegrationTest {
         orderMessageErrorConsumerAspect.getAfterOrderConsumedEventLatch().await(30, TimeUnit.SECONDS);
 
         // Get order received from retry topic
-        OrderReceived actual = KafkaTestUtils.getSingleRecord(orderReceivedRetryConsumer, kafkaTopics.getOrderReceivedRetry()).value();
+        OrderReceived actual = KafkaTestUtils.getSingleRecord(orderReceivedRetryConsumer, kafkaTopics.getOrderReceivedRetry(), 30000).value();
 
         // then
         assertEquals(0, orderMessageErrorConsumerAspect.getAfterOrderConsumedEventLatch().getCount());

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageErrorConsumerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderMessageErrorConsumerUnitTest.java
@@ -1,0 +1,166 @@
+package uk.gov.companieshouse.itemhandler.kafka;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.event.ConsumerStoppedEvent;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.messaging.Message;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.orders.OrderReceived;
+
+@ExtendWith(MockitoExtension.class)
+class OrderMessageErrorConsumerUnitTest {
+
+    @Mock
+    private Message<OrderReceived> message;
+
+    @Mock
+    private KafkaConsumer<String, OrderReceived> consumer;
+
+    @Mock
+    private OrderMessageHandler orderMessageHandler;
+
+    @Mock
+    private ErrorConsumerController errorConsumerController;
+
+    @Spy
+    private PartitionOffset partitionOffset = new PartitionOffset();
+
+    @Mock
+    private ConsumerStoppedEvent consumerStoppedEvent;
+
+    @Mock
+    private KafkaMessageListenerContainer<String, OrderReceived> kafkaMessageListenerContainer;
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private OrderMessageErrorConsumer orderMessageErrorConsumer;
+
+    @BeforeEach
+    void beforeEach() {
+        orderMessageErrorConsumer.setErrorGroup("item-handler-order-received-error");
+        orderMessageErrorConsumer.setErrorTopic("order-received-error");
+    }
+
+    @Test
+    void shouldNotHandleMessageAndShouldStopConsumerWhenOffsetIsEqualToRecoveryOffset() {
+        //given
+        when(partitionOffset.getOffset()).thenReturn(1L);
+
+        //when
+        orderMessageErrorConsumer.processOrderReceived(message, 1L, consumer);
+
+        //then
+        verify(orderMessageHandler, times(0)).handleMessage(message);
+        verify(errorConsumerController).pauseConsumerThread();
+    }
+
+    @Test
+    void shouldNotHandleMessageAndShouldStopConsumerWhenOffsetIsGreaterThanRecoveryOffset() {
+        //given
+        when(partitionOffset.getOffset()).thenReturn(1L);
+
+        //when
+        orderMessageErrorConsumer.processOrderReceived(message, 2L, consumer);
+
+        //then
+        verify(orderMessageHandler, times(0)).handleMessage(message);
+        verify(errorConsumerController).pauseConsumerThread();
+    }
+
+    @Test
+    void shouldHandleMessageAndStopConsumerWhenOffsetIsOneLessThanRecoveryOffset() {
+        //given
+        when(partitionOffset.getOffset()).thenReturn(1L);
+
+        //when
+        orderMessageErrorConsumer.processOrderReceived(message, 0L, consumer);
+
+        //then
+        verify(orderMessageHandler).handleMessage(message);
+        verify(errorConsumerController).pauseConsumerThread();
+    }
+
+    @Test
+    void shouldHandleMessageAndNotStopConsumerWhenOffsetIsTwoLessThanRecoveryOffset() {
+        //given
+        when(partitionOffset.getOffset()).thenReturn(2L);
+
+        //when
+        orderMessageErrorConsumer.processOrderReceived(message, 0L, consumer);
+
+        //then
+        verify(orderMessageHandler).handleMessage(message);
+        verify(errorConsumerController, times(0)).pauseConsumerThread();
+    }
+
+    @Test
+    void shouldStopConsumerThreadForErrorTopic() {
+        //given
+        when(consumerStoppedEvent.getSource(KafkaMessageListenerContainer.class)).thenReturn(kafkaMessageListenerContainer);
+        when(kafkaMessageListenerContainer.getBeanName()).thenReturn("item-handler-order-received-error-0");
+
+        //when
+        orderMessageErrorConsumer.consumerStopped(consumerStoppedEvent);
+
+        //then
+        verify(partitionOffset).clear();
+    }
+
+    @Test
+    void shouldNotStopConsumerThreadForRetryTopic() {
+        //given
+        when(consumerStoppedEvent.getSource(KafkaMessageListenerContainer.class)).thenReturn(kafkaMessageListenerContainer);
+        when(kafkaMessageListenerContainer.getBeanName()).thenReturn("item-handler-order-received-retry-0");
+
+        //when
+        orderMessageErrorConsumer.consumerStopped(consumerStoppedEvent);
+
+        //then
+        verify(partitionOffset, times(0)).clear();
+    }
+
+    @Test
+    void shouldNotSetErrorRecoveryOffsetWhenOffsetHasAlreadyBeenSet() {
+        //given
+        when(partitionOffset.getOffset()).thenReturn(null);
+
+        //when
+        orderMessageErrorConsumer.configureErrorRecoveryOffset(consumer);
+
+        //then
+        verify(partitionOffset, times(0)).setOffset(1L);
+    }
+
+    @Test
+    void shouldCorrectlySetErrorRecoveryOffsetFromConsumerEndOffsets() {
+        //given
+        when(consumer.endOffsets(any())).thenReturn(new HashMap<TopicPartition, Long>() {
+            {
+                put(new TopicPartition("order-received-error", 0), 1L);
+            }
+        });
+
+        //when
+        orderMessageErrorConsumer.configureErrorRecoveryOffset(consumer);
+
+        //then
+        verify(partitionOffset).setOffset(1L);
+        verify(logger).info("Setting Error Consumer Recovery Offset to '1'");
+    }
+}


### PR DESCRIPTION
* Rationalise default mode and error mode consumer factory configuration
* Add controller to allow integration tests to resume the error consumer thread

Relates to: [BI-9947 Fix issues with Kafka resilience in Item Handler](https://companieshouse.atlassian.net/browse/BI-9947)