### PR TITLE
BI-10838 populate good standing information for active companies

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/mapper/OrderDataToCertificateOrderConfirmationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/mapper/OrderDataToCertificateOrderConfirmationMapper.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.itemhandler.model.Address;
 import uk.gov.companieshouse.itemhandler.model.BasicInformationIncludable;
 import uk.gov.companieshouse.itemhandler.model.CertificateItemOptions;
 import uk.gov.companieshouse.itemhandler.model.CertificateType;
+import uk.gov.companieshouse.itemhandler.model.CompanyStatus;
 import uk.gov.companieshouse.itemhandler.model.ContentWrapper;
 import uk.gov.companieshouse.itemhandler.model.DirectorOrSecretaryDetails;
 import uk.gov.companieshouse.itemhandler.model.IncludeDobType;
@@ -77,8 +78,9 @@ public abstract class OrderDataToCertificateOrderConfirmationMapper implements M
         confirmation.setCertificateRegisteredOfficeOptions(mapCertificateRegisteredOfficeOptions(options.getRegisteredOfficeAddressDetails()));
         confirmation.setCertificateDirectorOptions(mapCertificateDirectorOptions(item));
         confirmation.setCertificateSecretaryOptions(mapCertificateSecretaryOptions(item));
-        confirmation.setCertificateGoodStandingInformation(new ContentWrapper<>(
-                Optional.ofNullable(options.getIncludeGoodStandingInformation()).map(this::mapCertificateOptionsText).orElse(null)));
+        if (CompanyStatus.ACTIVE == options.getCompanyStatus()) {
+            confirmation.setCertificateGoodStandingInformation(new ContentWrapper<>(mapCertificateOptionsText(options.getIncludeGoodStandingInformation())));
+        }
         confirmation.setCertificateSecretaries(mapIncludeBasicInformationText(options.getSecretaryDetails()));
         confirmation.setCertificateDirectors(mapIncludeBasicInformationText(options.getDirectorDetails()));
         confirmation.setCertificateCompanyObjects(mapCertificateOptionsText(options.getIncludeCompanyObjectsInformation()));

--- a/src/main/java/uk/gov/companieshouse/itemhandler/mapper/OrdersApiToOrderDataMapper.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/mapper/OrdersApiToOrderDataMapper.java
@@ -66,6 +66,7 @@ public interface OrdersApiToOrderDataMapper {
     CompanyType mapCompanyType(String companyType);
 
     @ValueMappings({
+            @ValueMapping(source = "active", target = "ACTIVE"),
             @ValueMapping(source = "liquidation", target = "LIQUIDATION"),
             @ValueMapping(source = MappingConstants.ANY_UNMAPPED, target = "OTHER")
     })

--- a/src/main/java/uk/gov/companieshouse/itemhandler/model/CompanyStatus.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/model/CompanyStatus.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.itemhandler.model;
 
 public enum CompanyStatus {
+    ACTIVE("active"),
     LIQUIDATION("liquidation"),
     OTHER("other");
 

--- a/src/test/java/uk/gov/companieshouse/itemhandler/mapper/OrderDataToCertificateOrderConfirmationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/mapper/OrderDataToCertificateOrderConfirmationMapperTest.java
@@ -213,7 +213,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
 
         final CertificateOrderConfirmation confirmation = mapperUnderTest.orderToConfirmation(order);
         assertInformationIsAsExpected(confirmation);
-        assertThat(confirmation.getCertificateGoodStandingInformation().getContent(), is("Yes"));
+        assertThat(confirmation.getCertificateGoodStandingInformation(), is(nullValue()));
         assertThat(confirmation.getCertificateDirectors(), is("No"));
         assertThat(confirmation.getCertificateSecretaries(), is("Yes"));
         assertThat(confirmation.getCertificateCompanyObjects(), is("Yes"));
@@ -245,6 +245,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
         options.setCompanyStatus(null);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -274,6 +275,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         options.setDirectorDetails(directors);
         options.setSecretaryDetails(null);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -305,6 +307,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -336,6 +339,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -366,6 +370,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -398,6 +403,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -430,6 +436,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -462,6 +469,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -494,6 +502,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -532,6 +541,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -575,6 +585,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -612,6 +623,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretaries.setIncludeBasicInformation(true);
         options.setSecretaryDetails(secretaries);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -646,6 +658,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretary.setIncludeAppointmentDate(true);
         options.setSecretaryDetails(secretary);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -679,6 +692,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretary.setIncludeAppointmentDate(false);
         options.setSecretaryDetails(secretary);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -712,6 +726,7 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         secretary.setIncludeAppointmentDate(false);
         options.setSecretaryDetails(secretary);
         options.setIncludeCompanyObjectsInformation(true);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         item.setItemOptions(options);
         order.setItems(singletonList(item));
@@ -848,13 +863,14 @@ class OrderDataToCertificateOrderConfirmationMapperTest {
         order.setOrderedAt(LocalDateTime.now());
         order.setTotalOrderCost("99");
         item.setItemOptions(options);
+        options.setCompanyStatus(CompanyStatus.ACTIVE);
 
         // When
         final CertificateOrderConfirmation confirmation = mapperUnderTest.orderToConfirmation(order);
 
         // Then
         assertInformationIsAsExpected(confirmation);
-        assertNull(confirmation.getCertificateGoodStandingInformation().getContent());
+        assertThat(confirmation.getCertificateGoodStandingInformation().getContent(), is("No"));
         assertThat(confirmation.getCertificateDirectors(), is("No"));
         assertThat(confirmation.getCertificateSecretaries(), is("No"));
         assertThat(confirmation.getCertificateCompanyObjects(), is("No"));

--- a/src/test/java/uk/gov/companieshouse/itemhandler/mapper/OrdersApiToOrderDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/mapper/OrdersApiToOrderDataMapperTest.java
@@ -512,19 +512,19 @@ class OrdersApiToOrderDataMapperTest {
     }
 
     @Test
-    @DisplayName("Correctly maps company status active to enumerated type")
+    @DisplayName("Correctly maps company status active to enumerated type ACTIVE")
     void testActiveCompanyStatusMapping() {
         assertThat(CompanyStatus.ACTIVE, is(mapper.mapCompanyStatus("active")));
     }
 
     @Test
-    @DisplayName("Correctly maps company status liquidation to enumerated type")
+    @DisplayName("Correctly maps company status liquidation to enumerated type LIQUIDATION")
     void testLiquidatedCompanyStatusMapping() {
         assertThat(CompanyStatus.LIQUIDATION, is(mapper.mapCompanyStatus("liquidation")));
     }
 
     @Test
-    @DisplayName("Correctly maps company status other to enumerated type")
+    @DisplayName("Correctly maps unmapped company status to enumerated type OTHER")
     void testOtherCompanyStatusMapping() {
         assertThat(CompanyStatus.OTHER, is(mapper.mapCompanyStatus("xyz")));
     }

--- a/src/test/java/uk/gov/companieshouse/itemhandler/mapper/OrdersApiToOrderDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/mapper/OrdersApiToOrderDataMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.itemhandler.mapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +36,7 @@ import uk.gov.companieshouse.api.model.order.item.RegisteredOfficeAddressDetails
 import uk.gov.companieshouse.itemhandler.model.ActionedBy;
 import uk.gov.companieshouse.itemhandler.model.CertificateItemOptions;
 import uk.gov.companieshouse.itemhandler.model.CertifiedCopyItemOptions;
+import uk.gov.companieshouse.itemhandler.model.CompanyStatus;
 import uk.gov.companieshouse.itemhandler.model.DeliveryDetails;
 import uk.gov.companieshouse.itemhandler.model.DirectorOrSecretaryDetails;
 import uk.gov.companieshouse.itemhandler.model.FilingHistoryDocument;
@@ -507,5 +509,23 @@ class OrdersApiToOrderDataMapperTest {
         item.setEtag(TOKEN_ETAG);
 
         return item;
+    }
+
+    @Test
+    @DisplayName("Correctly maps company status active to enumerated type")
+    void testActiveCompanyStatusMapping() {
+        assertThat(CompanyStatus.ACTIVE, is(mapper.mapCompanyStatus("active")));
+    }
+
+    @Test
+    @DisplayName("Correctly maps company status liquidation to enumerated type")
+    void testLiquidatedCompanyStatusMapping() {
+        assertThat(CompanyStatus.LIQUIDATION, is(mapper.mapCompanyStatus("liquidation")));
+    }
+
+    @Test
+    @DisplayName("Correctly maps company status other to enumerated type")
+    void testOtherCompanyStatusMapping() {
+        assertThat(CompanyStatus.OTHER, is(mapper.mapCompanyStatus("xyz")));
     }
 }


### PR DESCRIPTION
* Ensure that confirmation certificate statement of good standing information is populated for active companies

Resolves: [BI-10838 Statement of good standing doesn't render text as 'No' when unselected](https://companieshouse.atlassian.net/browse/BI-10838)