### PR TITLE
add logic to handle same day certs 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/service/EmailService.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.itemhandler.kafka.EmailSendMessageProducer;
 import uk.gov.companieshouse.itemhandler.logging.LoggingUtils;
 import uk.gov.companieshouse.itemhandler.mapper.OrderDataToCertificateOrderConfirmationMapper;
 import uk.gov.companieshouse.itemhandler.mapper.OrderDataToItemOrderConfirmationMapper;
+import uk.gov.companieshouse.itemhandler.model.DeliveryItemOptions;
 import uk.gov.companieshouse.itemhandler.model.OrderData;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -32,6 +33,10 @@ public class EmailService {
             "item-handler.certificate-order-confirmation";
     public static final String CERTIFICATE_ORDER_NOTIFICATION_API_MESSAGE_TYPE =
             "certificate_order_confirmation_email";
+    public static final String SAME_DAY_CERTIFICATE_ORDER_NOTIFICATION_API_APP_ID =
+            "item-handler.same-day-certificate-order-confirmation";
+    public static final String SAME_DAY_CERTIFICATE_ORDER_NOTIFICATION_API_MESSAGE_TYPE =
+            "same_day_certificate_order_confirmation_email";
     public static final String CERTIFIED_COPY_ORDER_NOTIFICATION_API_APP_ID =
             "item-handler.certified-copy-order-confirmation";
     public static final String CERTIFIED_COPY_ORDER_NOTIFICATION_API_MESSAGE_TYPE =
@@ -43,6 +48,7 @@ public class EmailService {
     public static final String ITEM_TYPE_CERTIFICATE = "certificate";
     public static final String ITEM_TYPE_CERTIFIED_COPY = "certified-copy";
     public static final String ITEM_TYPE_MISSING_IMAGE_DELIVERY = "missing-image-delivery";
+    public static final String STANDARD_DELIVERY = "standard";
 
     /**
      * This email address is supplied only to satisfy Avro contract.
@@ -116,14 +122,15 @@ public class EmailService {
      */
     private OrderConfirmationAndEmail buildOrderConfirmationAndEmail(final OrderData order) {
         final String descriptionId = order.getItems().get(0).getDescriptionIdentifier();
+        final String deliveryTimescale = ((DeliveryItemOptions) order.getItems().get(0).getItemOptions()).getDeliveryTimescale().getJsonName();
         final EmailSend email = new EmailSend();
         final OrderConfirmation confirmation;
         switch (descriptionId) {
             case ITEM_TYPE_CERTIFICATE:
                 confirmation = orderToCertificateOrderConfirmationMapper.orderToConfirmation(order, featureOptions);
                 confirmation.setTo(certificateOrderRecipient);
-                email.setAppId(CERTIFICATE_ORDER_NOTIFICATION_API_APP_ID);
-                email.setMessageType(CERTIFICATE_ORDER_NOTIFICATION_API_MESSAGE_TYPE);
+                email.setAppId(deliveryTimescale.equals(STANDARD_DELIVERY) ? CERTIFICATE_ORDER_NOTIFICATION_API_APP_ID : SAME_DAY_CERTIFICATE_ORDER_NOTIFICATION_API_APP_ID);
+                email.setMessageType(deliveryTimescale.equals(STANDARD_DELIVERY) ? CERTIFICATE_ORDER_NOTIFICATION_API_MESSAGE_TYPE : SAME_DAY_CERTIFICATE_ORDER_NOTIFICATION_API_MESSAGE_TYPE);
                 return new OrderConfirmationAndEmail(confirmation, email);
             case ITEM_TYPE_CERTIFIED_COPY:
                 confirmation = orderToItemOrderConfirmationMapper.orderToConfirmation(order);

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/EmailServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.itemhandler.service;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.itemhandler.model.DeliveryTimescale.STANDARD;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -17,6 +18,7 @@ import uk.gov.companieshouse.itemhandler.email.ItemOrderConfirmation;
 import uk.gov.companieshouse.itemhandler.kafka.EmailSendMessageProducer;
 import uk.gov.companieshouse.itemhandler.mapper.OrderDataToCertificateOrderConfirmationMapper;
 import uk.gov.companieshouse.itemhandler.mapper.OrderDataToItemOrderConfirmationMapper;
+import uk.gov.companieshouse.itemhandler.model.DeliveryItemOptions;
 import uk.gov.companieshouse.itemhandler.model.Item;
 import uk.gov.companieshouse.itemhandler.model.OrderData;
 
@@ -62,6 +64,9 @@ class EmailServiceIntegrationTest {
     @MockBean
     private ItemOrderConfirmation itemOrderConfirmation;
 
+    @MockBean
+    private DeliveryItemOptions deliveryItemOptions;
+
     @Test
     @DisplayName("EmailService sets the to line on the confirmation to the configured " +
             "certificate.order.confirmation.recipient value")
@@ -74,6 +79,8 @@ class EmailServiceIntegrationTest {
         when(order.getItems()).thenReturn(items);
         when(items.get(0)).thenReturn(item);
         when(item.getDescriptionIdentifier()).thenReturn(ITEM_TYPE_CERTIFICATE);
+        when(((DeliveryItemOptions) item.getItemOptions())).thenReturn(deliveryItemOptions);
+        when(deliveryItemOptions.getDeliveryTimescale()).thenReturn(STANDARD);
         emailServiceUnderTest.sendOrderConfirmation(order);
 
         // Then
@@ -92,6 +99,8 @@ class EmailServiceIntegrationTest {
         when(order.getItems()).thenReturn(items);
         when(items.get(0)).thenReturn(item);
         when(item.getDescriptionIdentifier()).thenReturn(ITEM_TYPE_CERTIFIED_COPY);
+        when(((DeliveryItemOptions) item.getItemOptions())).thenReturn(deliveryItemOptions);
+        when(deliveryItemOptions.getDeliveryTimescale()).thenReturn(STANDARD);
         emailServiceUnderTest.sendOrderConfirmation(order);
 
         // Then
@@ -111,6 +120,8 @@ class EmailServiceIntegrationTest {
         when(order.getItems()).thenReturn(items);
         when(items.get(0)).thenReturn(item);
         when(item.getDescriptionIdentifier()).thenReturn(ITEM_TYPE_MISSING_IMAGE_DELIVERY);
+        when(((DeliveryItemOptions) item.getItemOptions())).thenReturn(deliveryItemOptions);
+        when(deliveryItemOptions.getDeliveryTimescale()).thenReturn(STANDARD);
         emailServiceUnderTest.sendOrderConfirmation(order);
 
         // Then


### PR DESCRIPTION
Email service will now use the correct template dependant on delivery timescale of a certificate order (standard or same day). The same day template changes the email subject text to show it is a same day request.

Resolves: BI-11246