### PR TITLE
Add output for certs emails to show express delivery and if email copy required

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/email/CertificateOrderConfirmation.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/email/CertificateOrderConfirmation.java
@@ -12,6 +12,7 @@ public class CertificateOrderConfirmation extends OrderConfirmation {
     private String certificateType;
     private String[] certificateIncludes;
     private String deliveryMethod;
+    private String emailCopyRequired;
     private ContentWrapper<String> certificateGoodStandingInformation;
     private String certificateDirectors;
     private String certificateSecretaries;
@@ -118,6 +119,14 @@ public class CertificateOrderConfirmation extends OrderConfirmation {
 
     public void setDeliveryMethod(String deliveryMethod) {
         this.deliveryMethod = deliveryMethod;
+    }
+
+    public String getEmailCopyRequired() {
+        return emailCopyRequired;
+    }
+
+    public void setEmailCopyRequired(String emailCopyRequired) {
+        this.emailCopyRequired = emailCopyRequired;
     }
 
     public String getCertificateCompanyType() {

--- a/src/main/java/uk/gov/companieshouse/itemhandler/mapper/OrderDataToCertificateOrderConfirmationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/mapper/OrderDataToCertificateOrderConfirmationMapper.java
@@ -20,6 +20,7 @@ import uk.gov.companieshouse.itemhandler.model.CertificateItemOptions;
 import uk.gov.companieshouse.itemhandler.model.CertificateType;
 import uk.gov.companieshouse.itemhandler.model.CompanyStatus;
 import uk.gov.companieshouse.itemhandler.model.ContentWrapper;
+import uk.gov.companieshouse.itemhandler.model.DeliveryTimescale;
 import uk.gov.companieshouse.itemhandler.model.DirectorOrSecretaryDetails;
 import uk.gov.companieshouse.itemhandler.model.IncludeDobType;
 import uk.gov.companieshouse.itemhandler.model.Item;
@@ -239,7 +240,7 @@ public abstract class OrderDataToCertificateOrderConfirmationMapper implements M
     }
 
     private String mapDeliveryMethod (String timescale) {
-        if (timescale == "STANDARD") {
+        if (timescale.equals(DeliveryTimescale.STANDARD.toString())) {
              return toSentenceCase(timescale) + " delivery (aim to dispatch within " + dispatchDays
                             + " working days)";
         } else {
@@ -248,7 +249,7 @@ public abstract class OrderDataToCertificateOrderConfirmationMapper implements M
     }
 
     private String mapIsEmailRequired(CertificateItemOptions item) {
-        if (item.getDeliveryTimescale().toString() == "SAME_DAY") {
+        if (item.getDeliveryTimescale().toString().equals(DeliveryTimescale.SAME_DAY.toString())) {
             if (item.getIncludeEmailCopy()) {
                 return "Yes";
             } else {


### PR DESCRIPTION
bump api-enum add email copy required to cert order model add logic t…o set correct email copy output update delivery method to include express option output add and update tests

Resolves: BI-11199