### PR TITLE
GCI-2297 Map CHS hostname to link to view certificate

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/CertificateConfirmationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/CertificateConfirmationMapper.java
@@ -37,7 +37,11 @@ public class CertificateConfirmationMapper extends OrderConfirmationMapper<Certi
                 .map(item -> new CertificateSummary(item.getId(),
                         mapCertificateType(((CertificateItemOptions) item.getItemOptions()).getCertificateType()),
                         item.getCompanyNumber(),
-                        "£" + item.getTotalItemCost())
+                        "£" + item.getTotalItemCost(),
+                        String.format("%s/orders-admin/orders/%s/items/%s",
+                                config.getOrdersAdminHost(),
+                                itemGroup.getOrder().getReference(),
+                                item.getId()))
                 ).forEach(certificateEmailData::add);
     }
 

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/CertificateSummary.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/CertificateSummary.java
@@ -7,15 +7,17 @@ public class CertificateSummary {
     private String certificateType;
     private String companyNumber;
     private String fee;
+    private String viewCertificateLink;
 
     public CertificateSummary() {
     }
 
-    public CertificateSummary(String itemNumber, String certificateType, String companyNumber, String fee) {
+    public CertificateSummary(String itemNumber, String certificateType, String companyNumber, String fee, String viewCertificateLink) {
         this.itemNumber = itemNumber;
         this.certificateType = certificateType;
         this.companyNumber = companyNumber;
         this.fee = fee;
+        this.viewCertificateLink = viewCertificateLink;
     }
 
     public String getItemNumber() {
@@ -50,6 +52,14 @@ public class CertificateSummary {
         this.fee = fee;
     }
 
+    public String getViewCertificateLink() {
+        return viewCertificateLink;
+    }
+
+    public void setViewCertificateLink(String viewCertificateLink) {
+        this.viewCertificateLink = viewCertificateLink;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -62,11 +72,12 @@ public class CertificateSummary {
         return Objects.equals(getItemNumber(), that.getItemNumber())
                 && Objects.equals(getCertificateType(), that.getCertificateType())
                 && Objects.equals(getCompanyNumber(), that.getCompanyNumber())
-                && Objects.equals(getFee(), that.getFee());
+                && Objects.equals(getFee(), that.getFee())
+                && Objects.equals(getViewCertificateLink(), that.getViewCertificateLink());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getItemNumber(), getCertificateType(), getCompanyNumber(), getFee());
+        return Objects.hash(getItemNumber(), getCertificateType(), getCompanyNumber(), getFee(), getViewCertificateLink());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/EmailConfig.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/EmailConfig.java
@@ -13,6 +13,7 @@ public class EmailConfig {
 
     private CertificateEmailConfig certificate;
     private String senderEmail;
+    private String ordersAdminHost;
 
     public CertificateEmailConfig getCertificate() {
         return certificate;
@@ -28,5 +29,13 @@ public class EmailConfig {
 
     public void setSenderEmail(String senderEmail) {
         this.senderEmail = senderEmail;
+    }
+
+    public String getOrdersAdminHost() {
+        return ordersAdminHost;
+    }
+
+    public void setOrdersAdminHost(String ordersAdminHost) {
+        this.ordersAdminHost = ordersAdminHost;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,3 +34,4 @@ email.certificate.recipient = ${CERTIFICATE_ORDER_CONFIRMATION_RECIPIENT}
 email.certificate.standardSubjectLine = CHS certificate order
 email.certificate.expressSubjectLine = CHS Certificate Same day order
 email.senderEmail = noreply@companieshouse.gov.uk
+email.ordersAdminHost = ${CHS_URL}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/CertificateConfirmationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/CertificateConfirmationMapperTest.java
@@ -62,6 +62,7 @@ public class CertificateConfirmationMapperTest {
         // given
         when(deliverableItemGroup.getOrder()).thenReturn(order);
         when(config.getCertificate()).thenReturn(certificateEmailConfig);
+        when(config.getOrdersAdminHost()).thenReturn("host");
         when(certificateEmailConfig.getRecipient()).thenReturn("example@companieshouse.gov.uk");
         when(certificateEmailConfig.getStandardSubjectLine()).thenReturn("subject");
         when(order.getDeliveryDetails()).thenReturn(deliveryDetails);
@@ -86,7 +87,11 @@ public class CertificateConfirmationMapperTest {
                                                         .withOrderReference("ORD-123123-123123")
                                                         .withDeliveryDetails(deliveryDetails)
                                                         .withPaymentDetails(new PaymentDetails("payment reference", "25 August 2022 - 15:18:00"))
-                                                        .addCertificate(new CertificateSummary("CRT-123123-123123", "Incorporation with all company name changes", "12345678", "£15"))
+                                                        .addCertificate(new CertificateSummary("CRT-123123-123123",
+                                                                "Incorporation with all company name changes",
+                                                                "12345678",
+                                                                "£15",
+                                                                "host/orders-admin/orders/ORD-123123-123123/items/CRT-123123-123123"))
                                                         .build())));
         assertThat(emailMetadata.getAppId(), is("item-handler.certificate-summary-order-confirmation"));
         assertThat(emailMetadata.getMessageType(), is("certificate_summary_order_confirmation"));
@@ -98,6 +103,7 @@ public class CertificateConfirmationMapperTest {
         // given
         when(deliverableItemGroup.getOrder()).thenReturn(order);
         when(config.getCertificate()).thenReturn(certificateEmailConfig);
+        when(config.getOrdersAdminHost()).thenReturn("host");
         when(certificateEmailConfig.getRecipient()).thenReturn("example@companieshouse.gov.uk");
         when(certificateEmailConfig.getExpressSubjectLine()).thenReturn("subject");
         when(order.getDeliveryDetails()).thenReturn(deliveryDetails);
@@ -122,7 +128,11 @@ public class CertificateConfirmationMapperTest {
                 .withOrderReference("ORD-123123-123123")
                 .withDeliveryDetails(deliveryDetails)
                 .withPaymentDetails(new PaymentDetails("payment reference", "25 August 2022 - 15:18:00"))
-                .addCertificate(new CertificateSummary("CRT-123123-123123", "Dissolution with all company name changes", "12345678", "£15"))
+                .addCertificate(new CertificateSummary("CRT-123123-123123",
+                        "Dissolution with all company name changes",
+                        "12345678",
+                        "£15",
+                        "host/orders-admin/orders/ORD-123123-123123/items/CRT-123123-123123"))
                 .build())));
         assertThat(emailMetadata.getAppId(), is("item-handler.certificate-summary-order-confirmation"));
         assertThat(emailMetadata.getMessageType(), is("certificate_summary_order_confirmation"));
@@ -134,17 +144,18 @@ public class CertificateConfirmationMapperTest {
         // given
         when(deliverableItemGroup.getOrder()).thenReturn(order);
         when(config.getCertificate()).thenReturn(certificateEmailConfig);
+        when(config.getOrdersAdminHost()).thenReturn("host");
         when(certificateEmailConfig.getRecipient()).thenReturn("example@companieshouse.gov.uk");
         when(certificateEmailConfig.getStandardSubjectLine()).thenReturn("subject");
         when(order.getDeliveryDetails()).thenReturn(deliveryDetails);
         when(order.getReference()).thenReturn("ORD-123123-123123");
         when(order.getOrderedAt()).thenReturn(LocalDateTime.of(2022, 8,25, 15, 18));
         when(deliverableItemGroup.getItems()).thenReturn(Arrays.asList(item, item));
-        when(item.getId()).thenReturn("CRT-123123-123123");
+        when(item.getId()).thenReturn("CRT-123123-123123", "CRT-123123-123123", "CRT-123123-123124", "CRT-123123-123124");
         when(item.getItemOptions()).thenReturn(itemOptions);
         when(itemOptions.getCertificateType()).thenReturn(CertificateType.INCORPORATION_WITH_ALL_NAME_CHANGES, CertificateType.DISSOLUTION);
-        when(item.getCompanyNumber()).thenReturn("12345678");
-        when(item.getTotalItemCost()).thenReturn("15");
+        when(item.getCompanyNumber()).thenReturn("12345678", "87654321");
+        when(item.getTotalItemCost()).thenReturn("15", "50");
         when(order.getPaymentReference()).thenReturn("payment reference");
         when(deliverableItemGroup.getTimescale()).thenReturn(DeliveryTimescale.STANDARD);
 
@@ -158,8 +169,16 @@ public class CertificateConfirmationMapperTest {
                 .withOrderReference("ORD-123123-123123")
                 .withDeliveryDetails(deliveryDetails)
                 .withPaymentDetails(new PaymentDetails("payment reference", "25 August 2022 - 15:18:00"))
-                .addCertificate(new CertificateSummary("CRT-123123-123123", "Incorporation with all company name changes", "12345678", "£15"))
-                .addCertificate(new CertificateSummary("CRT-123123-123123", "Dissolution with all company name changes", "12345678", "£15"))
+                .addCertificate(new CertificateSummary("CRT-123123-123123",
+                        "Incorporation with all company name changes",
+                        "12345678",
+                        "£15",
+                        "host/orders-admin/orders/ORD-123123-123123/items/CRT-123123-123123"))
+                .addCertificate(new CertificateSummary("CRT-123123-123124",
+                        "Dissolution with all company name changes",
+                        "87654321",
+                        "£50",
+                        "host/orders-admin/orders/ORD-123123-123123/items/CRT-123123-123124"))
                 .build())));
         assertThat(emailMetadata.getAppId(), is("item-handler.certificate-summary-order-confirmation"));
         assertThat(emailMetadata.getMessageType(), is("certificate_summary_order_confirmation"));

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -32,3 +32,4 @@ email.certificate.recipient = demo@ch.gov.uk
 email.certificate.standardSubjectLine = CHS certificate order
 email.certificate.expressSubjectLine = CHS Certificate Same day order
 email.senderEmail = noreply@companieshouse.gov.uk
+email.ordersAdminHost = https://cidev.aws.chdev.org


### PR DESCRIPTION
* Add new ordersAdminHost property to EmailConfig.
* Add new viewCertificateLink property to EmailData.
* Map ordersAdminHost + order item summary to viewCertificateLink in
  certificate confirmation mapper.