### PR TITLE
DCAC-253: Build item groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <java.version>1.8</java.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <structured-logging.version>1.9.12</structured-logging.version>
+        <structured-logging.version>1.9.25</structured-logging.version>
         <gson.version>2.8.0</gson.version>
         <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
         <mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
@@ -29,11 +29,16 @@ public class DigitalOrderItemRouter implements Routable {
     public void route(final OrderData order) {
         // TODO DCAC-253 Structured logging?
         logger.info("Routing digital items from order " + order.getReference());
+        createItemGroups(order);
+    }
+
+    List<ItemGroup> createItemGroups(final OrderData order) {
         final List<ItemGroup> digitalItemGroups = order.getItems().stream()
                 .filter(item -> !item.getKind().equals(KIND_MISSING_IMAGE_DELIVERY) && !item.isPostalDelivery())
                 .map(item -> new ItemGroup(order, item.getKind(), singletonList(item)))
                 .collect(Collectors.toList());
         logItemGroupsCreated(order, digitalItemGroups);
+        return digitalItemGroups;
     }
 
     private void logItemGroupsCreated(final OrderData order, final List<ItemGroup> digitalItemGroups) {

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
@@ -36,16 +36,16 @@ public class DigitalOrderItemRouter implements Routable {
     private void logItemGroupsCreated(final OrderData order, final List<ItemGroup> digitalItemGroups) {
         // TODO DCAC-253 Structured logging?
         if (digitalItemGroups.isEmpty()) {
-            logger.info("No digital items were found, no digital item groups were created.");
+            logger.info("No digital items were found, no digital item groups were created.\n");
             return;
         }
         final StringBuilder sb = new StringBuilder();
         sb.append("For order " + order.getReference() + " created " + digitalItemGroups.size() +
-                " digital item groups:\n");
+                " digital item groups:\n \n");
         for (int i = 0; i < digitalItemGroups.size(); i++) {
             final ItemGroup ig = digitalItemGroups.get(i);
             sb.append("\n + IG " + (i + 1) + " with kind " + ig.getKind() + " and " + ig.getItems().size() + " items:\n"
-                    + describeItemGroup(digitalItemGroups.get(i)));
+                    + describeItemGroup(digitalItemGroups.get(i)) + "\n \n");
         }
         logger.info(sb.toString());
     }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
@@ -5,9 +5,10 @@ import uk.gov.companieshouse.itemhandler.model.OrderData;
 import uk.gov.companieshouse.itemhandler.service.Routable;
 import uk.gov.companieshouse.logging.Logger;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
 
 /**
  * Routes any digital items within the order on to digital processing
@@ -15,6 +16,8 @@ import java.util.stream.Collectors;
  */
 @Component
 public class DigitalOrderItemRouter implements Routable {
+
+    private static final String KIND_MISSING_IMAGE_DELIVERY = "item#missing-image-delivery";
 
     private final Logger logger;
 
@@ -27,8 +30,8 @@ public class DigitalOrderItemRouter implements Routable {
         // TODO DCAC-253 Structured logging?
         logger.info("Routing digital items from order " + order.getReference());
         final List<ItemGroup> digitalItemGroups = order.getItems().stream()
-                .filter(item -> !item.isPostalDelivery())
-                .map(item -> new ItemGroup(order, item.getKind(), Collections.singletonList(item)))
+                .filter(item -> !item.getKind().equals(KIND_MISSING_IMAGE_DELIVERY) && !item.isPostalDelivery())
+                .map(item -> new ItemGroup(order, item.getKind(), singletonList(item)))
                 .collect(Collectors.toList());
         logItemGroupsCreated(order, digitalItemGroups);
     }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
@@ -44,7 +44,7 @@ public class DigitalOrderItemRouter implements Routable {
                 " digital item groups:\n");
         for (int i = 0; i < digitalItemGroups.size(); i++) {
             final ItemGroup ig = digitalItemGroups.get(i);
-            sb.append(" + IG " + i + 1 + " with kind " + ig.getKind() + " and " + ig.getItems().size() + " items:\n"
+            sb.append("\n + IG " + (i + 1) + " with kind " + ig.getKind() + " and " + ig.getItems().size() + " items:\n"
                     + describeItemGroup(digitalItemGroups.get(i)));
         }
         logger.info(sb.toString());

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.itemhandler.itemsummary;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.itemhandler.model.OrderData;
+import uk.gov.companieshouse.itemhandler.service.Routable;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Routes any digital items within the order on to digital processing
+ * (eventually through the `item-group-ordered` topic).
+ */
+@Component
+public class DigitalOrderItemRouter implements Routable {
+
+    private final Logger logger;
+
+    public DigitalOrderItemRouter(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void route(final OrderData order) {
+        // TODO DCAC-253 Structured logging?
+        logger.info("Routing digital items from order " + order.getReference());
+        final List<ItemGroup> digitalItemGroups = order.getItems().stream()
+                .filter(item -> !item.isPostalDelivery())
+                .map(item -> new ItemGroup(order, item.getKind(), Collections.singletonList(item)))
+                .collect(Collectors.toList());
+        logItemGroupsCreated(order, digitalItemGroups);
+    }
+
+    private void logItemGroupsCreated(final OrderData order, final List<ItemGroup> digitalItemGroups) {
+        // TODO DCAC-253 Structured logging?
+        if (digitalItemGroups.isEmpty()) {
+            logger.info("No digital items were found, no digital item groups were created.");
+            return;
+        }
+        final StringBuilder sb = new StringBuilder();
+        sb.append("For order " + order.getReference() + " created " + digitalItemGroups.size() +
+                " digital item groups:\n");
+        for (int i = 0; i < digitalItemGroups.size(); i++) {
+            final ItemGroup ig = digitalItemGroups.get(i);
+            sb.append(" + IG " + i + 1 + " with kind " + ig.getKind() + " and " + ig.getItems().size() + " items:\n"
+                    + describeItemGroup(digitalItemGroups.get(i)));
+        }
+        logger.info(sb.toString());
+    }
+
+    private String describeItemGroup(final ItemGroup itemGroup) {
+        return itemGroup.getItems().stream()
+                .map(item -> " - + " + item.getId() + " [" + item.getKind() + "]")
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/itemhandler/service/OrderProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/service/OrderProcessorService.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemhandler.exception.NonRetryableException;
 import uk.gov.companieshouse.itemhandler.exception.RetryableException;
+import uk.gov.companieshouse.itemhandler.itemsummary.DigitalOrderItemRouter;
 import uk.gov.companieshouse.itemhandler.itemsummary.OrderItemRouter;
 import uk.gov.companieshouse.itemhandler.model.OrderData;
 
@@ -27,11 +28,11 @@ public class OrderProcessorService {
 
     private final OrdersApiClientService ordersApi;
     private final OrderItemRouter orderItemRouter;
-    private final Routable digitalOrderItemRouter;
+    private final DigitalOrderItemRouter digitalOrderItemRouter;
 
     public OrderProcessorService(final OrdersApiClientService ordersApi,
                                  final OrderItemRouter orderItemRouter,
-                                 final Routable digitalOrderItemRouter) {
+                                 final DigitalOrderItemRouter digitalOrderItemRouter) {
         this.ordersApi = ordersApi;
         this.orderItemRouter = orderItemRouter;
         this.digitalOrderItemRouter = digitalOrderItemRouter;

--- a/src/main/java/uk/gov/companieshouse/itemhandler/service/OrderProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/service/OrderProcessorService.java
@@ -27,10 +27,14 @@ public class OrderProcessorService {
 
     private final OrdersApiClientService ordersApi;
     private final OrderItemRouter orderItemRouter;
+    private final Routable digitalOrderItemRouter;
 
-    public OrderProcessorService(final OrdersApiClientService ordersApi, final OrderItemRouter orderItemRouter) {
+    public OrderProcessorService(final OrdersApiClientService ordersApi,
+                                 final OrderItemRouter orderItemRouter,
+                                 final Routable digitalOrderItemRouter) {
         this.ordersApi = ordersApi;
         this.orderItemRouter = orderItemRouter;
+        this.digitalOrderItemRouter = digitalOrderItemRouter;
     }
 
     /**
@@ -51,6 +55,7 @@ public class OrderProcessorService {
             logIfNotNull(logMap, ORDER_REFERENCE_NUMBER, order.getReference());
             getLogger().info("Processing order received", logMap);
             orderItemRouter.route(order);
+            digitalOrderItemRouter.route(order);
             responseBuilder.withStatus(OrderProcessResponse.Status.OK);
         } catch (RetryableException exception) {
             String msg = String.format("Service unavailable %s", exception.getMessage());

--- a/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouterTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouterTest.java
@@ -1,0 +1,149 @@
+package uk.gov.companieshouse.itemhandler.itemsummary;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.itemhandler.model.Item;
+import uk.gov.companieshouse.itemhandler.model.OrderData;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.itemhandler.util.TestConstants.KIND_CERTIFICATE;
+import static uk.gov.companieshouse.itemhandler.util.TestConstants.KIND_CERTIFIED_COPY;
+import static uk.gov.companieshouse.itemhandler.util.TestConstants.KIND_MISSING_IMAGE_DELIVERY;
+
+
+/**
+ * Unit tests the {@link DigitalOrderItemRouter} class.
+ */
+@ExtendWith(MockitoExtension.class)
+class DigitalOrderItemRouterTest {
+
+    @InjectMocks
+    private DigitalOrderItemRouter routerUnderTest;
+
+    @Mock
+    private OrderData order;
+
+    @Mock
+    private Logger logger;
+
+    @Mock Item item;
+
+    @Test
+    @DisplayName("Digital certificate is created")
+    void routeDigitalCertificate() {
+
+        when(order.getItems()).thenReturn(singletonList(item));
+        when(item.getKind()).thenReturn(KIND_CERTIFICATE);
+        when(item.isPostalDelivery()).thenReturn(false);
+
+        final List<ItemGroup> groups = routerUnderTest.createItemGroups(order);
+        assertThat(groups.size(), is(1));
+        assertThat(groups.get(0).getItems().size(), is(1));
+        assertThat(groups.get(0).getItems().get(0).getKind(), is(KIND_CERTIFICATE));
+    }
+
+    @Test
+    @DisplayName("Postal certificate is not created")
+    void routePostalCertificate() {
+
+        when(order.getItems()).thenReturn(singletonList(item));
+        when(item.getKind()).thenReturn(KIND_CERTIFICATE);
+        when(item.isPostalDelivery()).thenReturn(true);
+
+        final List<ItemGroup> groups = routerUnderTest.createItemGroups(order);
+        assertThat(groups.isEmpty(), is(true));
+    }
+
+    @Test
+    @DisplayName("Digital certified copy is created")
+    void routeDigitalCertifiedCopy() {
+
+        when(order.getItems()).thenReturn(singletonList(item));
+        when(item.getKind()).thenReturn(KIND_CERTIFIED_COPY);
+        when(item.isPostalDelivery()).thenReturn(false);
+
+        final List<ItemGroup> groups = routerUnderTest.createItemGroups(order);
+        assertThat(groups.size(), is(1));
+        assertThat(groups.get(0).getItems().size(), is(1));
+        assertThat(groups.get(0).getItems().get(0).getKind(), is(KIND_CERTIFIED_COPY));
+    }
+
+    @Test
+    @DisplayName("Postal certified copy is not created")
+    void routePostalCertifiedCopy() {
+
+        when(order.getItems()).thenReturn(singletonList(item));
+        when(item.getKind()).thenReturn(KIND_CERTIFIED_COPY);
+        when(item.isPostalDelivery()).thenReturn(true);
+
+        final List<ItemGroup> groups = routerUnderTest.createItemGroups(order);
+        assertThat(groups.isEmpty(), is(true));
+    }
+
+    @Test
+    @DisplayName("Missing image delivery is not created")
+    void routeMissingImageDelivery() {
+
+        when(order.getItems()).thenReturn(singletonList(item));
+        when(item.getKind()).thenReturn(KIND_MISSING_IMAGE_DELIVERY);
+
+        final List<ItemGroup> groups = routerUnderTest.createItemGroups(order);
+        assertThat(groups.isEmpty(), is(true));
+    }
+
+    @Test
+    @DisplayName("Mixed order is handled correctly")
+    void routeMixedOrder() {
+
+        final OrderData order  = new OrderData();
+        order.setItems(asList(
+                createItem("CRT-1", KIND_CERTIFICATE, true),
+                createItem("CRT-2", KIND_CERTIFICATE, true),
+                createItem("CRT-3", KIND_CERTIFICATE, false),
+                createItem("CC-1", KIND_CERTIFIED_COPY, true),
+                createItem("CC-2", KIND_CERTIFIED_COPY, false),
+                createItem("CC-3", KIND_CERTIFIED_COPY, false),
+                createItem("MID-1", KIND_MISSING_IMAGE_DELIVERY, true),
+                createItem("MID-2", KIND_MISSING_IMAGE_DELIVERY, false))
+        );
+
+        final List<ItemGroup> groups = routerUnderTest.createItemGroups(order);
+        assertThat(groups.isEmpty(), is(false));
+        assertThat(groups.size(), is(3));
+
+        final ItemGroup IG1 = groups.get(0);
+        assertThat(IG1.getKind(), is(KIND_CERTIFICATE));
+        assertThat(IG1.getItems().size(), is(1));
+        assertThat(IG1.getItems().get(0).getId(), is("CRT-1"));
+
+        final ItemGroup IG2 = groups.get(1);
+        assertThat(IG2.getKind(), is(KIND_CERTIFICATE));
+        assertThat(IG2.getItems().size(), is(1));
+        assertThat(IG2.getItems().get(0).getId(), is("CRT-2"));
+
+        final ItemGroup IG3 = groups.get(2);
+        assertThat(IG3.getKind(), is(KIND_CERTIFIED_COPY));
+        assertThat(IG3.getItems().size(), is(1));
+        assertThat(IG3.getItems().get(0).getId(), is("CC-1"));
+    }
+
+    private Item createItem(final String id, final String kind, final boolean isDigital) {
+        final Item item = new Item();
+        item.setId(id);
+        item.setKind(kind);
+        item.setPostalDelivery(!isDigital);
+        return item;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/OrderProcessorServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/OrderProcessorServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.itemhandler.exception.ApiException;
 import uk.gov.companieshouse.itemhandler.exception.NonRetryableException;
+import uk.gov.companieshouse.itemhandler.itemsummary.DigitalOrderItemRouter;
 import uk.gov.companieshouse.itemhandler.itemsummary.OrderItemRouter;
 import uk.gov.companieshouse.itemhandler.model.OrderData;
 
@@ -37,6 +38,9 @@ class OrderProcessorServiceTest {
     @Mock
     private OrderItemRouter orderItemRouter;
 
+    @Mock
+    private DigitalOrderItemRouter digitalOrderItemRouter;
+
     @Test
     void getsOrderAndSendsOutConfirmation() {
 
@@ -49,7 +53,8 @@ class OrderProcessorServiceTest {
 
         // Then
         verify(ordersApi).getOrderData(ORDER_URI);
-        verify(orderItemRouter).route(any(OrderData.class));
+        verify(orderItemRouter).route(order);
+        verify(digitalOrderItemRouter).route(order);
     }
 
     @Test
@@ -79,5 +84,6 @@ class OrderProcessorServiceTest {
         // then
         assertThat(actual.getStatus(), is(equalTo(OrderProcessResponse.Status.OK)));
         verify(orderItemRouter).route(order);
+        verify(digitalOrderItemRouter).route(order);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/itemhandler/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/util/TestConstants.java
@@ -12,4 +12,8 @@ public class TestConstants {
             "item-handler.certified-copy-summary-order-confirmation";
     public static final String CERTIFIED_COPY_ORDER_NOTIFICATION_API_MESSAGE_TYPE =
             "certified_copy_summary_order_confirmation";
+
+    public static final String KIND_CERTIFICATE = "item#certificate";
+    public static final String KIND_CERTIFIED_COPY = "item#certified-copy";
+    public static final String KIND_MISSING_IMAGE_DELIVERY  = "item#missing-image-delivery";
 }


### PR DESCRIPTION
* Uses pre-existing `ItemGroup` class to build an in-memory collection of digital item groups.
* These item groups are NOT persisted, as according to [the architecture](https://companieshouse.atlassian.net/wiki/spaces/Arch/pages/3345023147/Orders+Service+Admin+Functions#Architecture-Diagram), they are persisted within the `item-group-workflow-api`.
 * The fact that the item groups are not persisted also means that writing focused integration tests for this new feature prior to routing the item groups on is likely to be too time consuming at this point.
 * It also means the app currently logs the item groups it creates in some detail to give visibility of what it is doing.