### PR TITLE
DCAC-39: Ensure item-handler correctly routes all digital and non-digital items

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.itemhandler.itemsummary;
 
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.itemhandler.model.Item;
 import uk.gov.companieshouse.itemhandler.model.OrderData;
 import uk.gov.companieshouse.itemhandler.service.DigitalItemGroupSenderService;
 import uk.gov.companieshouse.itemhandler.service.Routable;
@@ -59,15 +58,9 @@ public class DigitalOrderItemRouter implements Routable {
         sb.append("For order " + orderNumber + " created " + digitalItemGroups.size() + " digital item groups:\n \n");
         for (int i = 0; i < digitalItemGroups.size(); i++) {
             final ItemGroup ig = digitalItemGroups.get(i);
-            sb.append("\n + IG " + (i + 1) + " | " + describeItemGroup(ig) + "\n");
+            sb.append("\n + IG " + (i + 1) + " | " + ig + "\n");
         }
         logger.info(sb.toString(), getLogMap(orderNumber));
-    }
-
-    private String describeItemGroup(final ItemGroup itemGroup) {
-        return itemGroup.getKind() + " | " + itemGroup.getItems().size() + " items | " + itemGroup.getItems().stream()
-                .map(Item::getId)
-                .collect(Collectors.joining(" | "));
     }
 
     private static Map<String, Object> getLogMap(final String orderNumber) {

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
@@ -5,13 +5,12 @@ import uk.gov.companieshouse.itemhandler.model.OrderData;
 import uk.gov.companieshouse.itemhandler.service.DigitalItemGroupSenderService;
 import uk.gov.companieshouse.itemhandler.service.Routable;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.util.DataMap;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
+import static uk.gov.companieshouse.itemhandler.logging.LoggingUtils.getLogMap;
 
 /**
  * Routes any digital items within the order on to digital processing
@@ -63,10 +62,4 @@ public class DigitalOrderItemRouter implements Routable {
         logger.info(sb.toString(), getLogMap(orderNumber));
     }
 
-    private static Map<String, Object> getLogMap(final String orderNumber) {
-        return new DataMap.Builder()
-                .orderId(orderNumber)
-                .build()
-                .getLogMap();
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/DigitalOrderItemRouter.java
@@ -1,7 +1,9 @@
 package uk.gov.companieshouse.itemhandler.itemsummary;
 
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.itemhandler.model.Item;
 import uk.gov.companieshouse.itemhandler.model.OrderData;
+import uk.gov.companieshouse.itemhandler.service.DigitalItemGroupSenderService;
 import uk.gov.companieshouse.itemhandler.service.Routable;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.util.DataMap;
@@ -21,9 +23,11 @@ public class DigitalOrderItemRouter implements Routable {
 
     private static final String KIND_MISSING_IMAGE_DELIVERY = "item#missing-image-delivery";
 
+    private final DigitalItemGroupSenderService digitalItemGroupSenderService;
     private final Logger logger;
 
-    public DigitalOrderItemRouter(Logger logger) {
+    public DigitalOrderItemRouter(DigitalItemGroupSenderService digitalItemGroupSenderService, Logger logger) {
+        this.digitalItemGroupSenderService = digitalItemGroupSenderService;
         this.logger = logger;
     }
 
@@ -31,7 +35,8 @@ public class DigitalOrderItemRouter implements Routable {
     public void route(final OrderData order) {
         final String orderNumber = order.getReference();
         logger.info("Routing digital items from order " + orderNumber + ".", getLogMap(orderNumber));
-        createItemGroups(order);
+        final List<ItemGroup> groups = createItemGroups(order);
+        groups.forEach(digitalItemGroupSenderService::sendItemGroupForDigitalProcessing);
     }
 
     List<ItemGroup> createItemGroups(final OrderData order) {
@@ -54,16 +59,15 @@ public class DigitalOrderItemRouter implements Routable {
         sb.append("For order " + orderNumber + " created " + digitalItemGroups.size() + " digital item groups:\n \n");
         for (int i = 0; i < digitalItemGroups.size(); i++) {
             final ItemGroup ig = digitalItemGroups.get(i);
-            sb.append("\n + IG " + (i + 1) + " with kind " + ig.getKind() + " and " + ig.getItems().size() + " items:\n"
-                    + describeItemGroup(digitalItemGroups.get(i)) + "\n \n");
+            sb.append("\n + IG " + (i + 1) + " | " + describeItemGroup(ig) + "\n");
         }
         logger.info(sb.toString(), getLogMap(orderNumber));
     }
 
     private String describeItemGroup(final ItemGroup itemGroup) {
-        return itemGroup.getItems().stream()
-                .map(item -> " - + " + item.getId() + " [" + item.getKind() + "]")
-                .collect(Collectors.joining("\n"));
+        return itemGroup.getKind() + " | " + itemGroup.getItems().size() + " items | " + itemGroup.getItems().stream()
+                .map(Item::getId)
+                .collect(Collectors.joining(" | "));
     }
 
     private static Map<String, Object> getLogMap(final String orderNumber) {

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/ItemGroup.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/ItemGroup.java
@@ -6,6 +6,7 @@ import uk.gov.companieshouse.itemhandler.model.OrderData;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class ItemGroup {
 
@@ -72,5 +73,13 @@ public class ItemGroup {
     @Override
     public int hashCode() {
         return Objects.hash(getOrder(), getKind(), getItems());
+    }
+
+    @Override
+    public String toString() {
+        final String numberOfItems = getItems().size() + "" + (getItems().size() > 1 ? " items | " : " item | ");
+        return getKind() + " | " + numberOfItems + getItems().stream()
+                .map(Item::getId)
+                .collect(Collectors.joining(" | "));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/OrderItemRouter.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/itemsummary/OrderItemRouter.java
@@ -38,7 +38,7 @@ public class OrderItemRouter implements Routable {
     private Map<String, Map<DeliveryTimescale, DeliverableItemGroup>> deliverableItemsByKindAndDeliveryTimescale(OrderData order) {
         return order.getItems()
                 .stream()
-                .filter(item -> item.getItemOptions() instanceof DeliveryItemOptions)
+                .filter(item ->  item.isPostalDelivery() && item.getItemOptions() instanceof DeliveryItemOptions)
                 .collect(Collectors.groupingBy(Item::getKind, Collectors.toMap(
                         item -> Optional.ofNullable(((DeliveryItemOptions) item.getItemOptions()).getDeliveryTimescale())
                                 .orElseThrow(() -> new NonRetryableException(String.format("Item [%s] is missing a delivery timescale", item.getId()))),

--- a/src/main/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/logging/LoggingUtils.java
@@ -6,6 +6,7 @@ import org.springframework.messaging.MessageHeaders;
 import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.logging.util.DataMap;
 import uk.gov.companieshouse.orders.OrderReceived;
 
 import java.util.HashMap;
@@ -105,5 +106,12 @@ public class LoggingUtils {
         logIfNotNull(logMap, ORDER_URI, message.getPayload().getOrderUri());
 
         return logMap;
+    }
+
+    public static Map<String, Object> getLogMap(final String orderNumber) {
+        return new DataMap.Builder()
+                .orderId(orderNumber)
+                .build()
+                .getLogMap();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderService.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.itemhandler.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.itemhandler.itemsummary.ItemGroup;
+import uk.gov.companieshouse.itemhandler.model.Item;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.stream.Collectors;
+
+/**
+ * Service responsible for dispatching a message for each digital item group in an order for digital processing via
+ * the <code>item-group-ordered</code> Kafka topic.
+ */
+@Service
+public class DigitalItemGroupSenderService {
+    private final Logger logger;
+
+    public DigitalItemGroupSenderService(Logger logger) {
+        this.logger = logger;
+    }
+
+    public void sendItemGroupForDigitalProcessing(final ItemGroup digitalItemGroup) {
+        logger.info("Sending digital item group " + describeItemGroup(digitalItemGroup) + " for digital processing.");
+        // TODO DCAC-254 Implement ItemGroupOrderedMessageProducer et al.
+    }
+
+    private String describeItemGroup(final ItemGroup itemGroup) {
+        return itemGroup.getKind() + " | " + itemGroup.getItems().size() + " items | " + itemGroup.getItems().stream()
+                .map(Item::getId)
+                .collect(Collectors.joining(" | "));
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemhandler.itemsummary.ItemGroup;
 import uk.gov.companieshouse.logging.Logger;
 
+import static uk.gov.companieshouse.itemhandler.logging.LoggingUtils.getLogMap;
+
 /**
  * Service responsible for dispatching a message for each digital item group in an order for digital processing via
  * the <code>item-group-ordered</code> Kafka topic.
@@ -17,7 +19,9 @@ public class DigitalItemGroupSenderService {
     }
 
     public void sendItemGroupForDigitalProcessing(final ItemGroup digitalItemGroup) {
-        logger.info("Sending digital item group " + digitalItemGroup + " for digital processing.");
+        logger.info("Sending digital item group " + digitalItemGroup + " for digital processing.",
+                getLogMap(digitalItemGroup.getOrder().getReference()));
+
         // TODO DCAC-254 Implement ItemGroupOrderedMessageProducer et al.
     }
 

--- a/src/main/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderService.java
@@ -2,10 +2,7 @@ package uk.gov.companieshouse.itemhandler.service;
 
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemhandler.itemsummary.ItemGroup;
-import uk.gov.companieshouse.itemhandler.model.Item;
 import uk.gov.companieshouse.logging.Logger;
-
-import java.util.stream.Collectors;
 
 /**
  * Service responsible for dispatching a message for each digital item group in an order for digital processing via
@@ -20,14 +17,8 @@ public class DigitalItemGroupSenderService {
     }
 
     public void sendItemGroupForDigitalProcessing(final ItemGroup digitalItemGroup) {
-        logger.info("Sending digital item group " + describeItemGroup(digitalItemGroup) + " for digital processing.");
+        logger.info("Sending digital item group " + digitalItemGroup + " for digital processing.");
         // TODO DCAC-254 Implement ItemGroupOrderedMessageProducer et al.
-    }
-
-    private String describeItemGroup(final ItemGroup itemGroup) {
-        return itemGroup.getKind() + " | " + itemGroup.getItems().size() + " items | " + itemGroup.getItems().stream()
-                .map(Item::getId)
-                .collect(Collectors.joining(" | "));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/OrderItemRouterTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/OrderItemRouterTest.java
@@ -100,6 +100,24 @@ class OrderItemRouterTest {
     void testOrderContainsNoDeliverableItems() {
         // given
         Item missingImageDelivery = getMissingImageDelivery();
+        missingImageDelivery.setPostalDelivery(true);
+        when(order.getItems()).thenReturn(Collections.singletonList(missingImageDelivery));
+
+        // when
+        orderItemRouter.route(order);
+
+        // then
+        verify(chdItemSenderService).sendItemsToChd(itemGroupCaptor.capture());
+        verifyNoInteractions(emailService);
+        assertEquals(new ItemGroup(order, "item#missing-image-delivery", new ArrayList<>(Collections.singletonList(missingImageDelivery))), itemGroupCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("Router ignores the postal delivery flag on MID items")
+    void testOrderContainsPostalMID() {
+        // given
+        final Item missingImageDelivery = getMissingImageDelivery();
+        missingImageDelivery.setPostalDelivery(true);
         when(order.getItems()).thenReturn(Collections.singletonList(missingImageDelivery));
 
         // when

--- a/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/OrderItemRouterTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/OrderItemRouterTest.java
@@ -134,6 +134,7 @@ class OrderItemRouterTest {
         item.setKind("item#missing-image-delivery");
 
         item.setItemOptions(new MissingImageDeliveryItemOptions());
+        item.setPostalDelivery(false);
         return item;
     }
 
@@ -144,6 +145,7 @@ class OrderItemRouterTest {
         DeliveryItemOptions itemOptions = new DeliveryItemOptions();
         itemOptions.setDeliveryTimescale(timescale);
         item.setItemOptions(itemOptions);
+        item.setPostalDelivery(true);
         return item;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/OrderItemRouterTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/itemsummary/OrderItemRouterTest.java
@@ -112,6 +112,23 @@ class OrderItemRouterTest {
     }
 
     @Test
+    @DisplayName("Router should not send order confirmations when order only contains digital items")
+    void testOrderContainsOnlyDigitalItems() {
+        // given
+        final Item digitalCertificate = getExpectedItem("item#certificate", DeliveryTimescale.STANDARD);
+        digitalCertificate.setPostalDelivery(false);
+        final Item digitalCopy = getExpectedItem("item#certified-copy", DeliveryTimescale.STANDARD);
+        digitalCopy.setPostalDelivery(false);
+        when(order.getItems()).thenReturn(Arrays.asList(digitalCertificate, digitalCopy));
+
+        // when
+        orderItemRouter.route(order);
+
+        // then
+        verifyNoInteractions(emailService);
+    }
+
+    @Test
     @DisplayName("Router should throw a non retryable exception when delivery timescale is null")
     void testOrderWithNullDeliveryTimescale() {
         // given

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderRoutingIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderRoutingIntegrationTest.java
@@ -134,7 +134,7 @@ class OrderRoutingIntegrationTest {
         assertEquals(0, emailService.getLatch().getCount());
         assertNotNull(emailService.getItemGroupSent());
         assertThat(emailService.getItemGroupSent().getItems().size(), is(1));
-        assertThat(emailService.getItemGroupSent().getItems().get(0).getId(), is("CCD-289716-962308"));
+        assertThat(emailService.getItemGroupSent().getItems().get(0).getId(), is("CRT-113516-962308"));
 
         assertEquals(0, digitalItemGroupSenderService.getLatch().getCount());
         assertNotNull(digitalItemGroupSenderService.getItemGroupSent());

--- a/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderRoutingIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/kafka/OrderRoutingIntegrationTest.java
@@ -1,0 +1,143 @@
+package uk.gov.companieshouse.itemhandler.kafka;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.JsonBody;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.utility.DockerImageName;
+import uk.gov.companieshouse.itemhandler.config.EmbeddedKafkaBrokerConfiguration;
+import uk.gov.companieshouse.itemhandler.config.TestEnvironmentSetupHelper;
+import uk.gov.companieshouse.itemhandler.service.ChdItemSenderServiceAspect;
+import uk.gov.companieshouse.itemhandler.service.DigitalItemGroupSenderServiceAspect;
+import uk.gov.companieshouse.itemhandler.service.EmailServiceAspect;
+import uk.gov.companieshouse.orders.OrderReceived;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+@SpringBootTest
+@Import(EmbeddedKafkaBrokerConfiguration.class)
+@TestPropertySource(locations = "classpath:application.properties",
+        properties={"uk.gov.companieshouse.item-handler.error-consumer=false"})
+class OrderRoutingIntegrationTest {
+
+    private static MockServerContainer container;
+    private MockServerClient client;
+
+    @Autowired
+    private KafkaProducer<String, OrderReceived> orderReceivedProducer;
+
+    @Autowired
+    private KafkaTopics kafkaTopics;
+
+    @Autowired
+    private ChdItemSenderServiceAspect chdItemSenderService;
+
+    @Autowired
+    private EmailServiceAspect emailService;
+
+    @Autowired
+    private DigitalItemGroupSenderServiceAspect digitalItemGroupSenderService;
+
+    @BeforeAll
+    static void before() {
+        container = new MockServerContainer(DockerImageName.parse(
+                "jamesdbloom/mockserver:mockserver-5.5.4"));
+        container.start();
+        TestEnvironmentSetupHelper.setEnvironmentVariable("API_URL",
+                "http://" + container.getHost() + ":" + container.getServerPort());
+        TestEnvironmentSetupHelper.setEnvironmentVariable("CHS_API_KEY", "123");
+        TestEnvironmentSetupHelper.setEnvironmentVariable("PAYMENTS_API_URL",
+                "http://" + container.getHost() + ":" + container.getServerPort());
+    }
+
+    @AfterAll
+    static void after() {
+        container.stop();
+    }
+
+    @BeforeEach
+    void setup() {
+        client = new MockServerClient(container.getHost(), container.getServerPort());
+    }
+
+    @AfterEach
+    void teardown() {
+        client.reset();
+    }
+
+    @Test
+    @DisplayName("All items within order are routed correctly")
+    void orderItemsRoutedCorrectly()  throws ExecutionException, InterruptedException, IOException {
+        // given
+        client.when(request()
+                        .withPath("/orders/ORD-111111-123123")
+                        .withMethod(HttpMethod.GET.toString()))
+                .respond(response()
+                        .withStatusCode(HttpStatus.OK.value())
+                        .withHeader(org.apache.http.HttpHeaders.CONTENT_TYPE, "application/json")
+                        .withBody(JsonBody.json(IOUtils.resourceToString(
+                                "/fixtures/mixed-order.json",
+                                StandardCharsets.UTF_8))));
+
+        // when
+        orderReceivedProducer.send(new ProducerRecord<>(kafkaTopics.getOrderReceived(),
+                kafkaTopics.getOrderReceived(),
+                getOrderReceived())).get();
+
+        chdItemSenderService.getLatch().await(30, SECONDS);
+        emailService.getLatch().await(30, SECONDS);
+        digitalItemGroupSenderService.getLatch().await(30, SECONDS);
+
+        // then
+        assertEquals(0, chdItemSenderService.getLatch().getCount());
+        assertNotNull(chdItemSenderService.getItemGroupSent());
+        assertThat(chdItemSenderService.getItemGroupSent().getItems().size(), is(1));
+        assertThat(chdItemSenderService.getItemGroupSent().getItems().get(0).getId(), is("MID-107116-962328"));
+
+        assertEquals(0, emailService.getLatch().getCount());
+        assertNotNull(emailService.getItemGroupSent());
+        assertThat(emailService.getItemGroupSent().getItems().size(), is(1));
+        assertThat(emailService.getItemGroupSent().getItems().get(0).getId(), is("CCD-289716-962308"));
+
+        assertEquals(0, digitalItemGroupSenderService.getLatch().getCount());
+        assertNotNull(digitalItemGroupSenderService.getItemGroupSent());
+        assertThat(digitalItemGroupSenderService.getItemGroupSent().getItems().size(), is(1));
+        assertThat(digitalItemGroupSenderService.getItemGroupSent().getItems().get(0).getId(), is("CCD-289716-962308"));
+    }
+
+    private OrderReceived getOrderReceived() {
+        OrderReceived orderReceived = new OrderReceived();
+        orderReceived.setOrderUri(getOrderReference());
+        return orderReceived;
+    }
+
+    private String getOrderReference() {
+        return "/orders/ORD-111111-123123";
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/ChdItemSenderServiceAspect.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/ChdItemSenderServiceAspect.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CountDownLatch;
 
 @Aspect
 @Component
-public class ChdItemSenderServiceAspect {
+public class ChdItemSenderServiceAspect implements SenderServiceAspect {
 
     private final CountDownLatch latch = new CountDownLatch(1);
     private ItemGroup itemGroupSent;

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/ChdItemSenderServiceAspect.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/ChdItemSenderServiceAspect.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.itemhandler.service;
+
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.itemhandler.itemsummary.ItemGroup;
+
+import java.util.concurrent.CountDownLatch;
+
+@Aspect
+@Component
+public class ChdItemSenderServiceAspect {
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private ItemGroup itemGroupSent;
+
+    @After(value = "execution(* uk.gov.companieshouse.itemhandler.service.ChdItemSenderService.sendItemsToChd(..)) && args(itemGroup)")
+    public void sendItemsToChd(final ItemGroup itemGroup) {
+        latch.countDown();
+        itemGroupSent = itemGroup;
+    }
+
+    public CountDownLatch getLatch() {
+        return latch;
+    }
+
+    public ItemGroup getItemGroupSent() {
+        return itemGroupSent;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderServiceAspect.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderServiceAspect.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.itemhandler.service;
+
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.itemhandler.itemsummary.ItemGroup;
+
+import java.util.concurrent.CountDownLatch;
+
+@Aspect
+@Component
+public class DigitalItemGroupSenderServiceAspect {
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private ItemGroup itemGroupSent;
+
+    @After(value = "execution(* uk.gov.companieshouse.itemhandler.service.DigitalItemGroupSenderService.sendItemGroupForDigitalProcessing(..)) && args(itemGroup)")
+    public void sendItemGroupForDigitalProcessing(final ItemGroup itemGroup) {
+        latch.countDown();
+        itemGroupSent = itemGroup;
+    }
+
+    public CountDownLatch getLatch() {
+        return latch;
+    }
+
+    public ItemGroup getItemGroupSent() {
+        return itemGroupSent;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderServiceAspect.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/DigitalItemGroupSenderServiceAspect.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CountDownLatch;
 
 @Aspect
 @Component
-public class DigitalItemGroupSenderServiceAspect {
+public class DigitalItemGroupSenderServiceAspect implements SenderServiceAspect {
 
     private final CountDownLatch latch = new CountDownLatch(1);
     private ItemGroup itemGroupSent;

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/EmailServiceAspect.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/EmailServiceAspect.java
@@ -3,19 +3,19 @@ package uk.gov.companieshouse.itemhandler.service;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.itemhandler.itemsummary.DeliverableItemGroup;
+import uk.gov.companieshouse.itemhandler.itemsummary.ItemGroup;
 
 import java.util.concurrent.CountDownLatch;
 
 @Aspect
 @Component
-public class EmailServiceAspect {
+public class EmailServiceAspect implements SenderServiceAspect {
 
     private final CountDownLatch latch = new CountDownLatch(1);
-    private DeliverableItemGroup itemGroupSent;
+    private ItemGroup itemGroupSent;
 
     @After(value = "execution(* uk.gov.companieshouse.itemhandler.service.EmailService.sendOrderConfirmation(..)) && args(itemGroup)")
-    public void sendOrderConfirmation(final DeliverableItemGroup itemGroup) {
+    public void sendOrderConfirmation(final ItemGroup itemGroup) {
         latch.countDown();
         itemGroupSent = itemGroup;
     }
@@ -24,7 +24,7 @@ public class EmailServiceAspect {
         return latch;
     }
 
-    public DeliverableItemGroup getItemGroupSent() {
+    public ItemGroup getItemGroupSent() {
         return itemGroupSent;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/EmailServiceAspect.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/EmailServiceAspect.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.itemhandler.service;
+
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.itemhandler.itemsummary.DeliverableItemGroup;
+
+import java.util.concurrent.CountDownLatch;
+
+@Aspect
+@Component
+public class EmailServiceAspect {
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private DeliverableItemGroup itemGroupSent;
+
+    @After(value = "execution(* uk.gov.companieshouse.itemhandler.service.EmailService.sendOrderConfirmation(..)) && args(itemGroup)")
+    public void sendOrderConfirmation(final DeliverableItemGroup itemGroup) {
+        latch.countDown();
+        itemGroupSent = itemGroup;
+    }
+
+    public CountDownLatch getLatch() {
+        return latch;
+    }
+
+    public DeliverableItemGroup getItemGroupSent() {
+        return itemGroupSent;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/itemhandler/service/SenderServiceAspect.java
+++ b/src/test/java/uk/gov/companieshouse/itemhandler/service/SenderServiceAspect.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.itemhandler.service;
+
+import uk.gov.companieshouse.itemhandler.itemsummary.ItemGroup;
+
+import java.util.concurrent.CountDownLatch;
+
+public interface SenderServiceAspect {
+    CountDownLatch getLatch();
+    ItemGroup getItemGroupSent();
+}

--- a/src/test/resources/fixtures/mixed-order.json
+++ b/src/test/resources/fixtures/mixed-order.json
@@ -1,0 +1,161 @@
+{
+    "ordered_at" : "2023-10-02T07:26:49.449Z",
+    "ordered_by" : {
+      "id" : "Y2VkZWVlMzhlZWFjY2M4MzQ3MT",
+      "email" : "demo@ch.gov.uk"
+    },
+    "links" : {
+      "self" : "/orders/ORD-844016-962315"
+    },
+    "payment_reference" : "JhWXXHa06wCiJuW",
+    "etag" : "760dac4d1976ddd099cb791356522450a9d1978b",
+    "delivery_details" : {
+      "company_name" : "CH",
+      "address_line_1" : "CH",
+      "address_line_2" : "CW",
+      "country" : "Cymru",
+      "forename" : "V",
+      "locality" : "Caerdydd",
+      "postal_code" : "CF14 3UZ",
+      "surname" : "J"
+    },
+    "items" : [
+      {
+        "id" : "MID-107116-962328",
+        "company_name" : "THE GIRLS' DAY SCHOOL TRUST",
+        "company_number" : "00006400",
+        "description" : "missing image delivery for company 00006400",
+        "description_identifier" : "missing-image-delivery",
+        "description_values" : {
+          "company_number" : "00006400",
+          "missing-image-delivery" : "missing image delivery for company 00006400"
+        },
+        "item_costs" : [
+          {
+            "discount_applied" : "0",
+            "item_cost" : "3",
+            "calculated_cost" : "3",
+            "product_type" : "missing-image-delivery-mortgage"
+          }
+        ],
+        "item_options" : {
+          "filing_history_date" : "1993-08-21",
+          "filing_history_description" : "legacy",
+          "filing_history_description_values" : {
+            "description" : "Declaration of satisfaction of mortgage/charge"
+          },
+          "filing_history_id" : "MDEzNzQ1OTcyOGFkaXF6a2N4",
+          "filing_history_type" : "403a",
+          "filing_history_category" : "mortgage"
+        },
+        "etag" : "b3c4ac179d3ee8a76c7fc8da4d630b4c145cacde",
+        "kind" : "item#missing-image-delivery",
+        "links" : {
+          "self" : "/orderable/missing-image-deliveries/MID-107116-962328"
+        },
+        "postal_delivery" : false,
+        "quantity" : 1,
+        "item_uri" : "/orderable/missing-image-deliveries/MID-107116-962328",
+        "status" : "unknown",
+        "postage_cost" : "0",
+        "total_item_cost" : "3"
+      },
+      {
+        "id" : "CRT-113516-962308",
+        "company_name" : "THE GIRLS' DAY SCHOOL TRUST",
+        "company_number" : "00006400",
+        "description" : "certificate for company 00006400",
+        "description_identifier" : "certificate",
+        "description_values" : {
+          "certificate" : "certificate for company 00006400",
+          "company_number" : "00006400"
+        },
+        "item_costs" : [
+          {
+            "discount_applied" : "0",
+            "item_cost" : "15",
+            "calculated_cost" : "15",
+            "product_type" : "certificate"
+          }
+        ],
+        "item_options" : {
+          "certificate_type" : "incorporation-with-all-name-changes",
+          "director_details" : {
+            "include_address" : true,
+            "include_appointment_date" : false,
+            "include_basic_information" : true,
+            "include_country_of_residence" : false,
+            "include_nationality" : false,
+            "include_occupation" : false
+          },
+          "include_email_copy" : false,
+          "registered_office_address_details" : {},
+          "secretary_details" : {},
+          "company_type" : "private-limited-shares-section-30-exemption",
+          "company_status" : "active",
+          "delivery_timescale" : "standard"
+        },
+        "etag" : "f2b68e84265bed024d79ad5c79a774274a206764",
+        "kind" : "item#certificate",
+        "links" : {
+          "self" : "/orderable/certificates/CRT-113516-962308"
+        },
+        "postal_delivery" : true,
+        "quantity" : 1,
+        "item_uri" : "/orderable/certificates/CRT-113516-962308",
+        "status" : "unknown",
+        "postage_cost" : "0",
+        "total_item_cost" : "15"
+      },
+      {
+        "id" : "CCD-289716-962308",
+        "company_name" : "THE GIRLS' DAY SCHOOL TRUST",
+        "company_number" : "00006400",
+        "description" : "certified copy for company 00006400",
+        "description_identifier" : "certified-copy",
+        "description_values" : {
+          "company_number" : "00006400",
+          "certified-copy" : "certified copy for company 00006400"
+        },
+        "item_costs" : [
+          {
+            "discount_applied" : "0",
+            "item_cost" : "50",
+            "calculated_cost" : "50",
+            "product_type" : "certified-copy-same-day"
+          }
+        ],
+        "item_options" : {
+          "filing_history_documents" : [
+            {
+              "filing_history_date" : "2010-02-12",
+              "filing_history_description" : "change-person-director-company-with-change-date",
+              "filing_history_description_values" : {
+                "change_date" : "2010-02-12",
+                "officer_name" : "Thomas David Wheare"
+              },
+              "filing_history_id" : "MzAwOTM2MDg5OWFkaXF6a2N4",
+              "filing_history_type" : "CH01",
+              "filing_history_cost" : "50"
+            }
+          ],
+          "delivery_method" : "postal",
+          "delivery_timescale" : "same-day"
+        },
+        "etag" : "4e8b25cd348249f36f96d157193aba1eac8cf171",
+        "kind" : "item#certified-copy",
+        "links" : {
+          "self" : "/orderable/certified-copies/CCD-289716-962308"
+        },
+        "postal_delivery" : false,
+        "quantity" : 1,
+        "item_uri" : "/orderable/certified-copies/CCD-289716-962308",
+        "status" : "unknown",
+        "postage_cost" : "0",
+        "total_item_cost" : "50"
+      }
+    ],
+    "kind" : "order",
+    "total_order_cost" : "160",
+    "reference" : "ORD-123123-123123"
+}


### PR DESCRIPTION
* Add the skeleton of an `DigitalItemGroupSenderService`, to be fleshed out in [DCAC-254](https://companieshouse.atlassian.net/browse/DCAC-254). For MVP this will eventually send digital item groups out for digital processing via the `item-group-ordered` topic.
* Filter out digital items from any C&C team emails currently sent.
* Verify that the resulting `ItemGroup` instances get sent out via the correct service (and thus eventually via the correct kafka topic) in each case, according to item kind and whether they are postal or digital.

[DCAC-254]: https://companieshouse.atlassian.net/browse/DCAC-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ